### PR TITLE
[FEAT] 모임 방 생성, 조회 API 추가

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
@@ -1,0 +1,28 @@
+package org.depromeet.team3.meeting.application
+
+import org.depromeet.team3.meeting.Meeting
+import org.depromeet.team3.meeting.MeetingRepository
+import org.depromeet.team3.meeting.dto.request.CreateMeetingRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateMeetingService(
+    private val meetingRepository: MeetingRepository
+) {
+
+    @Transactional
+    operator fun invoke(request: CreateMeetingRequest, userId: Long): Unit {
+        val meeting = Meeting(
+            null,
+            userId,
+            request.attendeeCount,
+            isClosed = false,
+            request.stationId,
+            request.endAt,
+            null, null
+        )
+
+        meetingRepository.save(meeting)
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingService.kt
@@ -1,0 +1,29 @@
+package org.depromeet.team3.meeting.application
+
+import org.depromeet.team3.meeting.MeetingRepository
+import org.depromeet.team3.meeting.dto.response.MeetingResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetMeetingService(
+    private val meetingRepository: MeetingRepository
+) {
+
+    @Transactional(readOnly = true)
+    operator fun invoke(userId: Long): List<MeetingResponse> {
+        return meetingRepository.findMeetingsByUserId(userId)
+            .map { meeting ->
+                MeetingResponse(
+                    id = meeting.id!!,
+                    hostUserId = meeting.hostUserId,
+                    attendeeCount = meeting.attendeeCount,
+                    isClosed = meeting.isClosed,
+                    stationId = meeting.stationId,
+                    endAt = meeting.endAt!!,
+                    createdAt = meeting.createdAt!!,
+                    updatedAt = meeting.updatedAt
+                )
+            }
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
@@ -1,0 +1,40 @@
+package org.depromeet.team3.meeting.controller
+
+import jakarta.validation.Valid
+import org.depromeet.team3.common.response.DpmApiResponse
+import org.depromeet.team3.meeting.application.CreateMeetingService
+import org.depromeet.team3.meeting.application.GetMeetingService
+import org.depromeet.team3.meeting.dto.request.CreateMeetingRequest
+import org.depromeet.team3.meeting.dto.response.MeetingResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/meetings")
+class MeetingController(
+    private val creteMeetingService: CreateMeetingService,
+    private val getMeetingService: GetMeetingService
+) {
+
+    @PostMapping
+    fun create(
+        userId: Long,
+        @RequestBody @Valid request: CreateMeetingRequest,
+    ) : DpmApiResponse<Unit> {
+        creteMeetingService(request, userId)
+
+        return DpmApiResponse.ok()
+    }
+
+    @GetMapping
+    fun getMeeting(
+        userId: Long
+    ) : DpmApiResponse<List<MeetingResponse>> {
+        val response = getMeetingService(userId)
+
+        return DpmApiResponse.ok(response)
+    }
+}

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/CreateMeetingRequest.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/CreateMeetingRequest.kt
@@ -1,0 +1,16 @@
+package org.depromeet.team3.meeting.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class CreateMeetingRequest(
+
+    @Schema(description = "모임 참여 인원", example = "1")
+    val attendeeCount: Int,
+
+    @Schema(description = "역 ID", example = "1")
+    val stationId: Long,
+
+    @Schema(description = "모임 종료 시간? 투표 시간?", example = "")
+    val endAt: LocalDateTime? = null,
+)

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/MeetingResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/MeetingResponse.kt
@@ -1,0 +1,14 @@
+package org.depromeet.team3.meeting.dto.response
+
+import java.time.LocalDateTime
+
+data class MeetingResponse(
+    val id: Long,
+    val hostUserId: Long,
+    val attendeeCount: Int,
+    val isClosed: Boolean,
+    val stationId: Long,
+    val endAt: LocalDateTime,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
+)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/BaseTimeDomain.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/BaseTimeDomain.kt
@@ -3,6 +3,6 @@ package org.depromeet.team3.common
 import java.time.LocalDateTime
 
 abstract class BaseTimeDomain(
-    open val createdAt: LocalDateTime,
+    open val createdAt: LocalDateTime? = null,
     open val updatedAt: LocalDateTime? = null,
 )

--- a/module-domain/src/main/kotlin/org/depromeet/team3/meeting/Meeting.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/meeting/Meeting.kt
@@ -10,7 +10,7 @@ data class Meeting(
     val isClosed: Boolean = false,
     val stationId: Long,
     val endAt: LocalDateTime? = null,
-    override val createdAt: LocalDateTime,
+    override val createdAt: LocalDateTime? = null,
     override val updatedAt: LocalDateTime? = null,
 ) : BaseTimeDomain(createdAt, updatedAt) {
 

--- a/module-domain/src/main/kotlin/org/depromeet/team3/meeting/MeetingRepository.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/meeting/MeetingRepository.kt
@@ -1,0 +1,8 @@
+package org.depromeet.team3.meeting
+
+interface MeetingRepository {
+
+    fun save(meeting: Meeting): Meeting
+
+    fun findMeetingsByUserId(userId: Long): List<Meeting>
+}

--- a/module-domain/src/test/kotlin/org/depromeet/team3/meeting/MeetingTest.kt
+++ b/module-domain/src/test/kotlin/org/depromeet/team3/meeting/MeetingTest.kt
@@ -19,6 +19,7 @@ class MeetingTest {
         val meeting = Meeting(
             hostUserId = hostUserId,
             attendeeCount = attendeeCount,
+            stationId = 1L,
             createdAt = now
         )
 
@@ -40,6 +41,7 @@ class MeetingTest {
             id = 1L,
             hostUserId = 1L,
             attendeeCount = 5,
+            stationId = 1L,
             createdAt = now
         )
 
@@ -47,6 +49,7 @@ class MeetingTest {
             id = 1L,
             hostUserId = 1L,
             attendeeCount = 5,
+            stationId = 1L,
             createdAt = now
         )
 

--- a/module-infra/src/main/kotlin/org/depromeet/team3/meeting/MeetingQuery.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/meeting/MeetingQuery.kt
@@ -1,0 +1,21 @@
+package org.depromeet.team3.meeting
+
+import org.depromeet.team3.mapper.MeetingMapper
+import org.springframework.stereotype.Repository
+
+@Repository
+class MeetingQuery(
+    private val meetingMapper: MeetingMapper,
+    private val meetingJpaRepository: MeetingJpaRepository
+) : MeetingRepository {
+
+    override fun save(meeting: Meeting): Meeting {
+        val entity = meetingMapper.toEntity(meeting)
+
+        return meetingMapper.toDomain(meetingJpaRepository.save(entity))
+    }
+
+    override fun findMeetingsByUserId(userId: Long): List<Meeting> {
+        return meetingJpaRepository.findByHostUserId(userId).map { meetingMapper.toDomain(it) }
+    }
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

-


## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 모임 생성/조회 API 제공: POST /meetings로 모임 생성, GET /meetings로 사용자 모임 목록 조회
  - 생성 요청 필드: 참여 인원(attendeeCount), 역 ID(stationId), 종료 시간(endAt, 선택)
  - 응답에 모임 ID, 호스트 ID, 참여 인원, 마감 여부, 역 ID, 종료/생성/수정 시간이 포함

- Documentation
  - 요청/응답 모델에 Swagger 스키마 추가로 OpenAPI 문서 가독성 및 예시 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->