### PR TITLE
[REFACTOR]: 모임 생성 참여 검증

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/common/ContextConstants.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/common/ContextConstants.kt
@@ -8,4 +8,6 @@ object ContextConstants {
 
     const val BASE_DOMAIN = "api.momuzzi.site"
     const val WWW_DOMAIN = "www.momuzzi.site"
+    const val HTTPS_PROTOCOL = "https://"
+
 }

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingService.kt
@@ -16,6 +16,7 @@ class GetMeetingService(
             .map { meeting ->
                 MeetingResponse(
                     id = meeting.id!!,
+                    name = meeting.name,
                     hostUserId = meeting.hostUserId,
                     attendeeCount = meeting.attendeeCount,
                     isClosed = meeting.isClosed,

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
@@ -14,19 +14,12 @@ import org.depromeet.team3.meeting.application.GetMeetingService
 import org.depromeet.team3.meeting.application.InviteTokenService
 import org.depromeet.team3.meeting.application.JoinMeetingService
 import org.depromeet.team3.meeting.dto.request.CreateMeetingRequest
-import org.depromeet.team3.meeting.dto.request.GenerateInviteTokenRequest
 import org.depromeet.team3.meeting.dto.request.JoinMeetingRequest
 import org.depromeet.team3.meeting.dto.response.CreateMeetingResponse
 import org.depromeet.team3.meeting.dto.response.InviteTokenResponse
 import org.depromeet.team3.meeting.dto.response.MeetingResponse
 import org.depromeet.team3.meeting.dto.response.ValidateInviteTokenResponse
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "모임", description = "모임 관련 API")
 @RestController
@@ -97,16 +90,12 @@ class MeetingController(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "초대 토큰 생성 성공")
     )
-    @PostMapping("/{meetingId}/invite")
+    @PostMapping("/{meetingId}/invite-token")
     fun createInviteLink(
         @Parameter(description = "모임 ID", example = "1")
-        @PathVariable meetingId: Long,
-        @RequestBody @Valid request: GenerateInviteTokenRequest
+        @PathVariable meetingId: Long
     ): DpmApiResponse<InviteTokenResponse> {
-        val response = inviteTokenService.generateInviteToken(
-            meetingId = meetingId,
-            baseUrl = request.baseUrl
-        )
+        val response = inviteTokenService.generateInviteToken(meetingId)
 
         return DpmApiResponse.ok(response)
     }
@@ -118,15 +107,13 @@ class MeetingController(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "모임 참여 성공")
     )
-    @PostMapping("/{meetingId}/join")
+    @PostMapping("/join")
     fun join(
-        @Parameter(description = "모임 ID", example = "1")
-        @PathVariable("meetingId") meetingId: Long,
         @Parameter(description = "사용자 ID", example = "123")
         @UserId userId: Long,
         @RequestBody @Valid request: JoinMeetingRequest
     ) : DpmApiResponse<Unit> {
-        joinMeetingService.invoke(meetingId, userId, request.attendeeNickname)
+        joinMeetingService.invoke(userId, request.meetingId, request.attendeeNickname)
 
         return DpmApiResponse.ok()
     }

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/GenerateInviteTokenRequest.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/GenerateInviteTokenRequest.kt
@@ -1,8 +1,0 @@
-package org.depromeet.team3.meeting.dto.request
-
-import io.swagger.v3.oas.annotations.media.Schema
-
-data class GenerateInviteTokenRequest(
-    @Schema(description = "앱의 기본 URL", example = "https://app.momuzzi.com")
-    val baseUrl: String,
-)

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/JoinMeetingRequest.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/request/JoinMeetingRequest.kt
@@ -2,8 +2,13 @@ package org.depromeet.team3.meeting.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class JoinMeetingRequest(
+    @Schema(description = "모임 ID", example = "1")
+    @field:NotNull(message = "모임 ID는 필수입니다.")
+    val meetingId: Long,
+
     @Schema(description = "모임에서 사용할 닉네임", example = "삼삼오오")
     @field:NotBlank(message = "닉네임은 필수입니다")
     val attendeeNickname: String,

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/InviteTokenResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/InviteTokenResponse.kt
@@ -3,9 +3,7 @@ package org.depromeet.team3.meeting.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class InviteTokenResponse(
-    @Schema(description = "초대 링크 URL", example = "https://app.momuzzi.com/meetings/join?token=abc123")
-    val inviteUrl: String,
-    
-    @Schema(description = "초대 토큰", example = "abc123")
-    val token: String,
+    @Schema(description = "토큰 검증 링크", example = "https://app.momuzzi.site/meetings/validate-invite?token=MSK@KS")
+    val validateTokenUrl: String
 )
+

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/MeetingResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/MeetingResponse.kt
@@ -7,6 +7,9 @@ import java.time.LocalDateTime
 data class MeetingResponse(
     @Schema(description = "모임 ID", example = "1")
     val id: Long,
+
+    @Schema(description = "모임 이름", example = "저녁 모무찌")
+    val name: String? = null,
     
     @Schema(description = "호스트 사용자 ID", example = "123")
     val hostUserId: Long,

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/ValidateInviteTokenResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/ValidateInviteTokenResponse.kt
@@ -3,15 +3,7 @@ package org.depromeet.team3.meeting.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ValidateInviteTokenResponse(
-    @Schema(description = "토큰 유효성", example = "true")
-    val isValid: Boolean,
-    
-    @Schema(description = "토큰 만료 여부", example = "false")
-    val isExpired: Boolean,
-    
-    @Schema(description = "모임 ID", example = "123")
-    val meetingId: Long?,
-    
-    @Schema(description = "검증 결과 메시지", example = "유효한 토큰입니다.")
-    val message: String
+    @Schema(description = "모임 ID", example = "1")
+    val meetingId: Long
 )
+

--- a/module-api/src/test/kotlin/org/depromeet/team3/meeting/util/MeetingTestDataFactory.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/meeting/util/MeetingTestDataFactory.kt
@@ -13,6 +13,7 @@ object MeetingTestDataFactory {
 
     fun createMeetingEntity(
         id: Long = 1L,
+        name: String = "테스트 미팅",
         attendeeCount: Int = 2,
         isClosed: Boolean = false,
         endAt: java.time.LocalDateTime? = null,
@@ -21,6 +22,7 @@ object MeetingTestDataFactory {
     ): MeetingEntity {
         return MeetingEntity(
             id = id,
+            name = name,
             attendeeCount = attendeeCount,
             isClosed = isClosed,
             endAt = endAt,

--- a/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/ErrorCode.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/common/exception/ErrorCode.kt
@@ -43,5 +43,14 @@ enum class ErrorCode(
     KAKAO_JSON_PARSE_ERROR("O003", "카카오 응답 데이터 파싱에 실패했습니다.", 500),
     KAKAO_API_ERROR("O004", "카카오 API 호출 중 오류가 발생했습니다.", 500),
     SOCIAL_LOGIN_INVALID_STATE("O005", "OAuth state 값이 유효하지 않습니다.", 400),
-    ALREADY_REGISTERED_WITH_OTHER_LOGIN("O006", "다른 소셜 로그인으로 이미 가입된 이메일입니다.", 409)
+    ALREADY_REGISTERED_WITH_OTHER_LOGIN("O006", "다른 소셜 로그인으로 이미 가입된 이메일입니다.", 409),
+
+    // 초대 토큰 관련 에러 (T001~T099)
+    INVALID_INVITE_TOKEN("T001", "유효하지 않은 초대 토큰입니다.", 400),
+    INVALID_TOKEN_FORMAT("T002", "토큰 형식이 올바르지 않습니다.", 400),
+    INVALID_MEETING_ID_IN_TOKEN("T003", "토큰의 모임 ID 형식이 올바르지 않습니다.", 400),
+    INVALID_EXPIRY_TIME_IN_TOKEN("T004", "토큰의 만료 시간 형식이 올바르지 않습니다.", 400),
+    TOKEN_EXPIRED("T005", "만료된 초대 토큰입니다.", 401),
+    MEETING_NOT_FOUND_FOR_TOKEN("T006", "토큰에 해당하는 모임을 찾을 수 없습니다.", 404),
+    MEETING_ALREADY_CLOSED("T007", "이미 종료된 모임입니다.", 409),
 }

--- a/module-domain/src/main/kotlin/org/depromeet/team3/meeting/exception/InvalidInviteTokenException.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/meeting/exception/InvalidInviteTokenException.kt
@@ -1,0 +1,9 @@
+package org.depromeet.team3.meeting.exception
+
+import org.depromeet.team3.common.exception.DpmException
+import org.depromeet.team3.common.exception.ErrorCode
+
+class InvalidInviteTokenException(
+    errorCode: ErrorCode,
+    detail: Map<String, Any?>? = null
+) : DpmException(errorCode, detail)

--- a/module-domain/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeRepository.kt
+++ b/module-domain/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeRepository.kt
@@ -12,5 +12,7 @@ interface MeetingAttendeeRepository {
 
     fun existsByMeetingIdAndUserId(meetingId: Long, userId: Long): Boolean
 
+    fun countByMeetingId(meetingId: Long): Int
+
     fun deleteById(id: Long)
 }

--- a/module-domain/src/test/kotlin/org/depromeet/team3/meeting/MeetingTest.kt
+++ b/module-domain/src/test/kotlin/org/depromeet/team3/meeting/MeetingTest.kt
@@ -17,6 +17,7 @@ class MeetingTest {
 
         // when
         val meeting = Meeting(
+            name = "테스트 미팅",
             hostUserId = hostUserId,
             attendeeCount = attendeeCount,
             stationId = 1L,
@@ -39,6 +40,7 @@ class MeetingTest {
         val now = LocalDateTime.now()
         val meeting1 = Meeting(
             id = 1L,
+            name = "테스트 미팅 1",
             hostUserId = 1L,
             attendeeCount = 5,
             stationId = 1L,
@@ -47,6 +49,7 @@ class MeetingTest {
 
         val meeting2 = Meeting(
             id = 1L,
+            name = "테스트 미팅 1",
             hostUserId = 1L,
             attendeeCount = 5,
             stationId = 1L,

--- a/module-infra/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeJpaRepository.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeJpaRepository.kt
@@ -8,5 +8,6 @@ interface MeetingAttendeeJpaRepository : JpaRepository<MeetingAttendeeEntity, Lo
     fun findByMeetingId(meetingId: Long): List<MeetingAttendeeEntity>
     fun findByUserId(userId: Long): List<MeetingAttendeeEntity>
     fun findByMeetingIdAndUserId(meetingId: Long, userId: Long): MeetingAttendeeEntity?
+    fun countByMeetingId(meetingId: Long): Int
     fun existsByMeetingIdAndUserId(meetingId: Long, userId: Long): Boolean
 }

--- a/module-infra/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeQuery.kt
+++ b/module-infra/src/main/kotlin/org/depromeet/team3/meetingattendee/MeetingAttendeeQuery.kt
@@ -40,6 +40,10 @@ class MeetingAttendeeQuery(
         return meetingAttendeeJpaRepository.existsByMeetingIdAndUserId(meetingId, userId)
     }
 
+    override fun countByMeetingId(meetingId: Long): Int {
+        return meetingAttendeeJpaRepository.countByMeetingId(meetingId)
+    }
+
     override fun deleteById(id: Long) {
         meetingAttendeeJpaRepository.deleteById(id)
     }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용
- 요청, 응답 스펙 변경
- 모임 생성, 참여 토큰 발급 테스트
- 참여 토큰 검증 -> 모임 참여 테스트


## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 초대 토큰 생성 시 단일 “검증 링크(URL)” 제공 및 명확한 오류 코드 응답.
  * 모임 참가 시 정원 초과·중복 참가 방지 검증 추가.
  * 모임 조회 응답에 ‘name(모임 이름)’ 필드 추가.

* 리팩터링
  * 초대 링크 생성 엔드포인트 경로 변경: POST /{meetingId}/invite-token (요청 본문 제거).
  * 참가 엔드포인트 경로 변경: POST /join, 요청에 meetingId 포함하도록 수정.
  * 초대 토큰 검증 응답을 meetingId 단일 필드로 단순화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->