### PR TITLE
[FIX] Next.js 컨테이너 배포 시 Nginx DNS 에러 해결

### DIFF
--- a/module-infra/nginx/nginx.conf
+++ b/module-infra/nginx/nginx.conf
@@ -19,7 +19,7 @@ http {
     }
 
     upstream frontend {
-        server deploy-web-1:3000;
+        server deploy-web-1:3000 max_fails=1 fail_timeout=30s;
     }
 
     upstream docker_registry {
@@ -186,7 +186,8 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
-            proxy_pass http://frontend;
+            set $frontend_upstream http://deploy-web-1:3000;
+            proxy_pass $frontend_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -206,7 +207,8 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
-            proxy_pass http://frontend;
+            set $frontend_upstream http://deploy-web-1:3000;
+            proxy_pass $frontend_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/srv/momuzzi/deploy/compose.yaml
+++ b/srv/momuzzi/deploy/compose.yaml
@@ -12,9 +12,10 @@ services:
     healthcheck:
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1" ]
       interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    stop_grace_period: 10s
 
 networks:
   depromeet_network:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- `set $frontend_upstream http://deploy-web-1:3000;` 로, 프론트 컨테이너가 동적 DNS 로 올바르게 Nginx 의 Upstream 으로 연결되도록 수정 

- Graceful shutdown 추가 (프론트 CICD 할때 라이트한 무중단 배포 옵션 느낌인데 생각나서 넣어봤음)


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 간헐적 접속 실패를 줄여 프런트엔드 연결 안정성을 향상했습니다.
- Refactor
  - 프록시 라우팅 방식을 정비해 장애 발생 시 복구 응답성을 개선했습니다.
- Chores
  - 헬스체크, 타임아웃, 재시도, 시작 지연 및 종료 유예 시간을 조정해 배포 중 가용성과 종료 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->