### PR TITLE
[REFACTOR] 유저 정보 파싱 파라미터 서버 내부에서만 사용하도록 변경

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/common/annotation/UserId.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/common/annotation/UserId.kt
@@ -1,5 +1,7 @@
 package org.depromeet.team3.common.annotation
 
+import io.swagger.v3.oas.annotations.Parameter
+
 /**
  * JWT 토큰에서 사용자 ID를 추출하여 컨트롤러 메서드 파라미터에 주입하는 어노테이션
  * 
@@ -12,4 +14,5 @@ package org.depromeet.team3.common.annotation
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
+@Parameter(hidden = true)
 annotation class UserId

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
@@ -40,7 +40,6 @@ class MeetingController(
     )
     @GetMapping
     fun getMeeting(
-        @Parameter(description = "사용자 ID", example = "123")
         @UserId userId: Long
     ) : DpmApiResponse<List<MeetingResponse>> {
         val response = getMeetingService(userId)
@@ -74,7 +73,6 @@ class MeetingController(
     )
     @PostMapping
     fun create(
-        @Parameter(description = "사용자 ID", example = "123")
         @UserId userId: Long,
         @RequestBody @Valid request: CreateMeetingRequest,
     ) : DpmApiResponse<CreateMeetingResponse> {
@@ -109,7 +107,6 @@ class MeetingController(
     )
     @PostMapping("/join")
     fun join(
-        @Parameter(description = "사용자 ID", example = "123")
         @UserId userId: Long,
         @RequestBody @Valid request: JoinMeetingRequest
     ) : DpmApiResponse<Unit> {

--- a/module-api/src/main/kotlin/org/depromeet/team3/survey/controller/SurveyController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/survey/controller/SurveyController.kt
@@ -38,7 +38,6 @@ class SurveyController(
     fun createSurvey(
         @Parameter(description = "모임 ID", example = "1")
         @PathVariable meetingId: Long,
-        @Parameter(description = "사용자 ID", example = "123")
         @UserId userId: Long,
         @RequestBody @Valid request: SurveyCreateRequest
     ): DpmApiResponse<SurveyCreateResponse> {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #55 

## 🔑 주요 내용

- 유저 정보 파싱 파라미터 서버 내부에서만 사용하도록 변경하였슴니다


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화
  * API 문서에서 내부용 userId 파라미터를 숨겨 보다 간결한 스펙을 제공합니다.
  * Meeting 엔드포인트(get, create, join)와 Survey 생성 엔드포인트에서 불필요한 파라미터 표기를 제거했습니다.
  * OpenAPI 생성 결과가 명확해져 소비자 혼선을 줄입니다.
  * 런타임 동작이나 요청/응답 형식에는 변화가 없으며, 인증/식별은 기존 방식대로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->