### PR TITLE
[FIX] MeetingAttendee 생성 로직 및 JoinMeetingService 테스트 토큰 생성 오류 해결

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
@@ -17,32 +17,33 @@ class CreateMeetingService(
 ) {
 
     @Transactional
-    operator fun invoke(request: CreateMeetingRequest, userId: Long)
-    : CreateMeetingResponse {
+    operator fun invoke(request: CreateMeetingRequest, userId: Long): CreateMeetingResponse {
         val meeting = Meeting(
-            null,
-            request.name,
-            userId,
-            request.attendeeCount,
+            id = null,
+            name = request.name,
+            hostUserId = userId,
+            attendeeCount = request.attendeeCount,
             isClosed = false,
-            request.stationId,
-            request.endAt,
-            null, null
+            stationId = request.stationId,
+            endAt = request.endAt,
+            createdAt = null,
+            updatedAt = null
         )
 
-        val save = meetingRepository.save(meeting)
+        val savedMeeting = meetingRepository.save(meeting)
 
         val meetingAttendee = MeetingAttendee(
-            null,
-            save.id!!,
-            userId,
-            request.attendeeNickname,
-            MuzziColor.DEFAULT,
-            null, null
+            id = null,
+            meetingId = savedMeeting.id!!,
+            userId = userId,
+            attendeeNickname = null,
+            muzziColor = MuzziColor.DEFAULT,
+            createdAt = null,
+            updatedAt = null
         )
 
         meetingAttendeeRepository.save(meetingAttendee)
 
-        return CreateMeetingResponse(save.id!!)
+        return CreateMeetingResponse(savedMeeting.id!!)
     }
 }

--- a/module-api/src/test/kotlin/org/depromeet/team3/meeting/application/JoinMeetingServiceTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/meeting/application/JoinMeetingServiceTest.kt
@@ -8,6 +8,7 @@ import org.depromeet.team3.meetingattendee.MeetingAttendee
 import org.depromeet.team3.meetingattendee.MeetingAttendeeRepository
 import org.depromeet.team3.meetingattendee.MuzziColor
 import org.depromeet.team3.meetingattendee.exception.MeetingAttendeeException
+import org.depromeet.team3.util.DataEncoder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -41,7 +42,7 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 1L
         val meetingId = 100L
-        val attendeeNickname = "테스트닉네임"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
         
         val meeting = MeetingTestDataFactory.createMeeting(
             id = meetingId,
@@ -59,7 +60,7 @@ class JoinMeetingServiceTest {
         whenever(meetingAttendeeRepository.save(any())).thenAnswer { it.arguments[0] }
 
         // When
-        joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+        joinMeetingService.invoke(userId, token)
 
         // Then
         val attendeeCaptor = argumentCaptor<MeetingAttendee>()
@@ -67,7 +68,6 @@ class JoinMeetingServiceTest {
         
         val savedAttendee = attendeeCaptor.firstValue
         assertEquals(MuzziColor.DEFAULT, savedAttendee.muzziColor)
-        assertEquals(attendeeNickname, savedAttendee.attendeeNickname)
         assertEquals(userId, savedAttendee.userId)
         assertEquals(meetingId, savedAttendee.meetingId)
     }
@@ -77,7 +77,7 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 10L
         val meetingId = 200L
-        val attendeeNickname = "삼삼오오"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
         
         val meeting = MeetingTestDataFactory.createMeeting(
             id = meetingId,
@@ -95,7 +95,7 @@ class JoinMeetingServiceTest {
         whenever(meetingAttendeeRepository.save(any())).thenAnswer { it.arguments[0] }
 
         // When
-        joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+        joinMeetingService.invoke(userId, token)
 
         // Then
         val attendeeCaptor = argumentCaptor<MeetingAttendee>()
@@ -103,7 +103,6 @@ class JoinMeetingServiceTest {
         
         val savedAttendee = attendeeCaptor.firstValue
         assertNotNull(savedAttendee)
-        assertEquals(attendeeNickname, savedAttendee.attendeeNickname)
         assertEquals(MuzziColor.DEFAULT, savedAttendee.muzziColor)
     }
 
@@ -112,13 +111,13 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 1L
         val meetingId = 999L
-        val attendeeNickname = "테스트"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
 
         whenever(meetingRepository.findById(meetingId)).thenReturn(null)
 
         // When & Then
         val exception = assertThrows<MeetingException> {
-            joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+            joinMeetingService.invoke(userId, token)
         }
         
         assertEquals(ErrorCode.MEETING_NOT_FOUND, exception.errorCode)
@@ -129,7 +128,7 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 1L
         val meetingId = 100L
-        val attendeeNickname = "테스트"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
         
         val closedMeeting = MeetingTestDataFactory.createMeeting(
             id = meetingId,
@@ -145,7 +144,7 @@ class JoinMeetingServiceTest {
 
         // When & Then
         val exception = assertThrows<MeetingException> {
-            joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+            joinMeetingService.invoke(userId, token)
         }
         
         assertEquals(ErrorCode.MEETING_ALREADY_CLOSED, exception.errorCode)
@@ -156,7 +155,7 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 1L
         val meetingId = 100L
-        val attendeeNickname = "테스트"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
         
         val meeting = MeetingTestDataFactory.createMeeting(
             id = meetingId,
@@ -183,7 +182,7 @@ class JoinMeetingServiceTest {
 
         // When & Then
         val exception = assertThrows<MeetingAttendeeException> {
-            joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+            joinMeetingService.invoke(userId, token)
         }
         
         assertEquals(ErrorCode.MEETING_ALREADY_JOINED, exception.errorCode)
@@ -194,7 +193,7 @@ class JoinMeetingServiceTest {
         // Given
         val userId = 1L
         val meetingId = 100L
-        val attendeeNickname = "테스트"
+        val token = DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")
         
         val meeting = MeetingTestDataFactory.createMeeting(
             id = meetingId,
@@ -212,10 +211,9 @@ class JoinMeetingServiceTest {
 
         // When & Then
         val exception = assertThrows<MeetingException> {
-            joinMeetingService.invoke(userId, meetingId, attendeeNickname)
+            joinMeetingService.invoke(userId, token)
         }
         
         assertEquals(ErrorCode.MEETING_FULL, exception.errorCode)
     }
 }
-


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #84 

## 🔑 주요 내용

- CreateMeetingService 함수 반환 타입 수정 및 파라미터명 수정
- 모든 테스트 메서드의 파라미터를 invoke(userId, token) 형태로 변경
- 각 테스트에 토큰 생성 로직 추가 `DataEncoder.encodeWithSeparator(":", meetingId.toString(), "validKey")`
- 불필요한 attendeeNickname 변수 및 관련 검증 로직 제거


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **리팩터**
  * 내부 서비스 메서드 정렬 및 코드 구조 최적화

* **테스트**
  * 테스트 케이스 업데이트 및 토큰 기반 검증 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->