### PR TITLE
[FIX] GetSurveyListServiceTest, UpdateSurveyCategoryServiceTest 오류 해결

### DIFF
--- a/module-api/src/test/kotlin/org/depromeet/team3/survey/application/GetSurveyListServiceTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/survey/application/GetSurveyListServiceTest.kt
@@ -96,19 +96,6 @@ class GetSurveyListServiceTest {
             categoryIds = listOf(3L)
         )
 
-        val cuisineCategory = SurveyTestDataFactory.createSurveyCategory(
-            id = 1L,
-            name = "한식"
-        )
-        val ingredientCategory = SurveyTestDataFactory.createSurveyCategory(
-            id = 2L,
-            name = "글루텐"
-        )
-        val menuCategory = SurveyTestDataFactory.createSurveyCategory(
-            id = 3L,
-            name = "내장"
-        )
-
         val participant1 = MeetingAttendeeTestDataFactory.createMeetingAttendee(
             id = 1L,
             meetingId = meetingId,
@@ -129,9 +116,6 @@ class GetSurveyListServiceTest {
         whenever(surveyRepository.findByMeetingId(meetingId)).thenReturn(listOf(survey1, survey2))
         whenever(surveyResultRepository.findBySurveyId(1L)).thenReturn(surveyResults1)
         whenever(surveyResultRepository.findBySurveyId(2L)).thenReturn(surveyResults2)
-        whenever(surveyCategoryRepository.findById(1L)).thenReturn(cuisineCategory)
-        whenever(surveyCategoryRepository.findById(2L)).thenReturn(ingredientCategory)
-        whenever(surveyCategoryRepository.findById(3L)).thenReturn(menuCategory)
         whenever(meetingAttendeeRepository.findByMeetingIdAndUserId(meetingId, participantId1)).thenReturn(participant1)
         whenever(meetingAttendeeRepository.findByMeetingIdAndUserId(meetingId, participantId2)).thenReturn(participant2)
 

--- a/module-api/src/test/kotlin/org/depromeet/team3/surveycategory/application/UpdateSurveyCategoryServiceTest.kt
+++ b/module-api/src/test/kotlin/org/depromeet/team3/surveycategory/application/UpdateSurveyCategoryServiceTest.kt
@@ -104,15 +104,7 @@ class UpdateSurveyCategoryServiceTest {
             sortOrder = 5
         )
 
-        val parentCategory = SurveyTestDataFactory.createSurveyCategory(
-            id = 2L,
-            level = SurveyCategoryLevel.BRANCH,
-            name = "부모 카테고리",
-            sortOrder = 1
-        )
-
         `when`(surveyCategoryRepository.findByIdAndIsDeletedFalse(categoryId)).thenReturn(existingCategory)
-        `when`(surveyCategoryRepository.findByIdAndIsDeletedFalse(2L)).thenReturn(parentCategory)
         `when`(surveyCategoryRepository.countChildrenByParentIdAndIsDeletedFalse(categoryId)).thenReturn(0L)
         `when`(surveyCategoryRepository.existsByNameAndParentIdAndIsDeletedFalse("피해야할 재료", 2L, categoryId)).thenReturn(false)
         `when`(surveyCategoryRepository.existsBySortOrderAndParentIdAndIsDeletedFalseAndIdNot(5, 2L, categoryId)).thenReturn(false)


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- surveyCategoryRepository.findById() 관련 stubbing 3개가 불필요 => 불필요한 변수 및 stubbing 제거
- UpdateSurveyCategoryService는 parentId를 그대로 저장만 하고, 부모 카테고리 존재 여부를 검증하지 않음 => 불필요한 변수 제거 parentCategory 및 stubbing 제거


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Tests**
  * 테스트 인프라 최적화를 위해 불필요한 테스트 데이터 설정 제거

---

**참고**: 이번 변경사항은 내부 테스트 구조 개선으로, 사용자가 인식할 수 있는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->