### PR TITLE
[FEATURE] 모임 내 초대 토큰 조회 기능 구현

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
@@ -65,6 +65,26 @@ class MeetingController(
     }
 
     @Operation(
+        summary = "모임 초대 토큰 조회",
+        description = "특정 모임의 초대 토큰을 조회합니다."
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "초대 토큰 조회 성공"),
+        ApiResponse(responseCode = "400", description = "잘못된 요청 (모임이 존재하지 않거나 종료된 경우)")
+    )
+    @GetMapping("/{meetingId}/invite-token")
+    fun getInviteToken(
+        @Parameter(description = "모임 ID", example = "5")
+        @PathVariable meetingId: Long
+    ): DpmApiResponse<GetInviteTokenResponse> {
+        val inviteUrl = inviteTokenService.generateInviteToken(meetingId)
+        val token = inviteUrl.substringAfter("token=")
+        val response = GetInviteTokenResponse(token = token)
+
+        return DpmApiResponse.ok(response)
+    }
+
+    @Operation(
         summary = "모임 초대 토큰 검증",
         description = "모임 초대 토큰의 유효성을 검증합니다."
     )

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/GetInviteTokenResponse.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/dto/response/GetInviteTokenResponse.kt
@@ -1,0 +1,9 @@
+package org.depromeet.team3.meeting.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "모임 초대 토큰 조회 응답")
+data class GetInviteTokenResponse(
+    @Schema(description = "초대 토큰", example = "MSK@KS...")
+    val token: String
+)


### PR DESCRIPTION

## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- meeting_id 를 통해 해당 모임의 초대 토큰을 조회합니다. (개발 용도 api임)



## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 모임 초대 토큰 조회 기능이 추가되었습니다. 특정 모임에 대한 고유한 초대 토큰을 생성하고 조회할 수 있으며, 이를 통해 모임 멤버 초대 프로세스가 더욱 간편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->