### PR TITLE
[FIX] 모임 생성 시 호스트 닉네임 NULL 설정

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/CreateMeetingService.kt
@@ -38,7 +38,7 @@ class CreateMeetingService(
         val savedMeeting = meetingRepository.save(meeting)
         val meetingId = savedMeeting.id ?: throw IllegalStateException("Meeting ID is null")
 
-        // 사용자 정보 조회하여 닉네임 가져오기
+        // 사용자 정보 조회
         val user = userRepository.findById(userId)
             .orElseThrow { 
                 MeetingException(
@@ -51,7 +51,7 @@ class CreateMeetingService(
             id = null,
             meetingId = meetingId,
             userId = userId,
-            attendeeNickname = user.nickname,
+            attendeeNickname = null,
             muzziColor = MuzziColor.DEFAULT,
             createdAt = null,
             updatedAt = null


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- Oauth 사용자 닉네임 설정하던 것을 null로 수정


## Check List

- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 미팅 생성 프로세스에서 참석자 정보 처리 방식이 개선되었습니다. 이전에는 참석자 닉네임이 자동으로 사용자 계정의 닉네임에서 파생되었으나, 이제는 더 이상 자동 설정되지 않습니다. 참석자 정보 관리 시 더 나은 제어가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->