### PR TITLE
[FEATURE] 종료된 모임 정보 조회 API 추가

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingDetailService.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/application/GetMeetingDetailService.kt
@@ -32,12 +32,16 @@ class GetMeetingDetailService(
 ) {
 
     @Transactional
-    operator fun invoke(meetingId: Long, userId: Long): MeetingDetailResponse {
+    operator fun invoke(
+        meetingId: Long,
+        userId: Long,
+        allowClosed: Boolean = false
+    ): MeetingDetailResponse {
         // 모임 조회 및 endAt 기반 자동 종료 처리
         val meeting = findAndAutoCloseIfExpired(meetingId)
         
         // 종료 모임 검증
-        if (meeting.isClosed) {
+        if (meeting.isClosed && !allowClosed) {
             throw MeetingException(
                 ErrorCode.MEETING_ALREADY_CLOSED,
                 mapOf(

--- a/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/meeting/controller/MeetingController.kt
@@ -65,6 +65,24 @@ class MeetingController(
     }
 
     @Operation(
+        summary = "종료된 모임 상세 정보 조회",
+        description = "endAt이 지난 모임도 동일한 응답 스키마로 조회합니다."
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "종료된 모임 상세 정보 조회 성공")
+    )
+    @GetMapping("/{meetingId}/history")
+    fun getMeetingDetailHistory(
+        @Parameter(description = "모임 ID", example = "1")
+        @PathVariable meetingId: Long,
+        @UserId userId: Long
+    ): DpmApiResponse<MeetingDetailResponse> {
+        val response = getMeetingDetailService.invoke(meetingId, userId, allowClosed = true)
+
+        return DpmApiResponse.ok(response)
+    }
+
+    @Operation(
         summary = "모임 초대 토큰 조회",
         description = "특정 모임의 초대 토큰을 조회합니다."
     )


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- 기존의 `/meetings/{id}` 반환값과 동일하지만, 모임 endAt 초과 시 에러 반환하지 않고 상세 정보 반환하도록 하였습니다. 


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 종료된 모임의 상세 정보를 조회할 수 있는 새로운 API 엔드포인트 추가
  * 모임 조회 시 종료된 상태도 함께 조회 가능하도록 개선

* **테스트**
  * 종료된 모임 상세 조회 기능에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->