### PR TITLE
[CHORE] React Native 소셜 로그인 Redirect Uri 추가

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/auth/controller/AuthController.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/auth/controller/AuthController.kt
@@ -49,6 +49,7 @@ class AuthController(
                 type = "string",
                 allowableValues = [
                     "http://localhost:3000/auth/callback",
+                    "http://192.168.35.119:3000/auth/callback",
                     "http://localhost:8080/auth/callback", 
                     "https://www.momuzzi.site/auth/callback",
                     "https://api.momuzzi.site/auth/callback"

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -22,5 +22,6 @@ app:
 kakao:
   redirect-uris:
     - http://localhost:3000/auth/callback
+    - http://192.168.35.119:3000/auth/callback
     - https://www.momuzzi.site/auth/callback
     - https://api.momuzzi.site/auth/callback

--- a/module-infrastructure/src/main/kotlin/org/depromeet/team3/auth/client/KakaoOAuthClient.kt
+++ b/module-infrastructure/src/main/kotlin/org/depromeet/team3/auth/client/KakaoOAuthClient.kt
@@ -25,6 +25,7 @@ class KakaoOAuthClient(
     private fun getAllowedRedirectUris(): Set<String> {
         val hardcodedUris = setOf(
             "http://localhost:3000/auth/callback",
+            "http://192.168.35.119:3000/auth/callback",
             "http://localhost:8080/auth/callback",
             "https://api.momuzzi.site/auth/callback",
             "https://www.momuzzi.site/auth/callback"


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

-

## 🔑 주요 내용

- 소셜 로그인 redirect-uri 추가(내부용도라 외부에서 접근 못하기에 환경변수 처리 안했슴니다)


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Kakao 소셜 로그인 인증 시스템에 새로운 리다이렉트 경로가 추가되었습니다. 인증 검증, API 요청 파라미터 검증, 프로덕션 환경 설정이 함께 업데이트되어 사용자가 새로운 환경에서도 Kakao 로그인을 정상적으로 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->