### PR TITLE
[FEATURE] Nginx와 WAS 간 MDC 로그 일관성 확보

### DIFF
--- a/module-api/src/main/kotlin/org/depromeet/team3/common/filter/MdcLoggingFilter.kt
+++ b/module-api/src/main/kotlin/org/depromeet/team3/common/filter/MdcLoggingFilter.kt
@@ -3,7 +3,6 @@ package org.depromeet.team3.common.filter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.stereotype.Component
 import org.springframework.util.AntPathMatcher
@@ -16,17 +15,21 @@ import java.util.*
  * 각 HTTP 요청마다 고유한 request_id를 생성하여 MDC에 저장하고,
  * 요청 처리 시간과 기본 정보를 로깅합니다.
  * 
+ * Nginx에서 전달된 X-RequestID 헤더가 있으면 우선 사용하고,
+ * 없으면 UUID 기반으로 생성합니다.
+ * 이를 통해 Nginx 로그와 WAS 로그를 동일한 request_id로 추적할 수 있습니다.
+ * 
  * 멀티스레드 환경에서 동일한 요청의 로그를 추적할 수 있도록 합니다.
  */
 @Component
 class MdcLoggingFilter : OncePerRequestFilter() {
     
-    private val logger = LoggerFactory.getLogger(MdcLoggingFilter::class.java)
     private val pathMatcher = AntPathMatcher()
-    
+
     companion object {
         const val REQUEST_ID = "request_id"
-        
+        const val X_REQUEST_ID_HEADER = "X-RequestID"
+
         // 필터를 적용하지 않을 URL 패턴 목록
         private val WHITE_LIST = listOf(
             "/actuator/**",
@@ -36,28 +39,41 @@ class MdcLoggingFilter : OncePerRequestFilter() {
         )
     }
 
+    /**
+     * HTTP 요청 처리 전후로 MDC 설정 및 로깅을 수행합니다.
+     * 
+     * 동작 순서:
+     * 1. X-RequestID 헤더 확인 (Nginx에서 전달된 request_id)
+     * 2. 헤더가 없으면 UUID 기반 고유한 request_id 생성 (8자리)
+     * 3. MDC에 request_id 저장
+     * 4. 요청 처리 시작 시간 기록
+     * 5. 다음 필터 체인으로 요청 전달
+     * 6. 요청 처리 완료 후 처리 시간 계산 및 로깅
+     * 7. MDC 정리 (finally 블록에서 항상 실행)
+     * 
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param filterChain 필터 체인
+     */
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        // 고유한 요청 ID 생성 (UUID의 앞 8자리만 사용)
-        val requestId = UUID.randomUUID().toString().substring(0, 8)
+        // Nginx에서 전달된 X-RequestID 헤더를 우선 확인
+        val requestId = request.getHeader(X_REQUEST_ID_HEADER)
+            ?: UUID.randomUUID().toString().substring(0, 8)
         MDC.put(REQUEST_ID, requestId)
         
         val startTime = System.currentTimeMillis()
         
         try {
-            // 다음 필터 체인으로 요청 전달
             filterChain.doFilter(request, response)
         } finally {
-            // 요청 처리 완료 후 로깅
             val duration = System.currentTimeMillis() - startTime
             logger.info(
                 "HTTP Request Completed - status=${response.status} method=${request.method} uri=${request.requestURI} duration=${duration}ms"
             )
-            
-            // MDC 정리 (다른 요청에 영향을 주지 않도록)
             MDC.clear()
         }
     }

--- a/module-infrastructure/nginx/nginx-app.conf
+++ b/module-infrastructure/nginx/nginx-app.conf
@@ -14,6 +14,13 @@ http {
     sendfile on;
     keepalive_timeout 65;
     
+    # 로그 포맷 정의 (request_id 포함)
+    log_format main '$request_id $remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" "$request_time" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    '"$ssl_protocol/$ssl_cipher" "$content_length" '
+                    '"$request_length"';
+    
     upstream backend {
         server backend:8080;
     }
@@ -52,10 +59,14 @@ http {
         ssl_ciphers HIGH:!aNULL:!MD5;
         ssl_prefer_server_ciphers on;
 
+        # access_log 설정 (request_id 포함)
+        access_log /var/log/nginx/access.log main;
+
         location /swagger-ui/ {
             proxy_pass http://backend/swagger-ui/;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-RequestID $request_id;
             proxy_redirect off;
         }
 
@@ -66,6 +77,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
+
+            # Nginx의 request_id를 WAS로 전달
+            proxy_set_header X-RequestID $request_id;
             proxy_pass_request_headers on;
 
             proxy_redirect off;


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #134 

## 🔑 주요 내용

- `proxy_set_header X-RequestID $request_id;` 를 통해 Nginx와 WAS(Tomcat) 간의 MDC 로깅 일관성 확보
-  MDC에서는 `X-RequestID` 헤더를 우선 확인 후, 헤더가 없을 시 UUID 기반 request_id 사용하도로 함
-  Nginx와 WAS 로그에서 동일한 request_id로 추적 가능


## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 요청 추적 ID 관리 시스템 개선 – 헤더 기반 식별자 우선 사용으로 분산 환경에서의 요청 추적 효율성 향상
  * 로깅 필터 최적화 – 특정 경로에 대한 불필요한 필터링 처리 제거로 성능 개선
  * 로그 레코드 확대 – 요청 추적 정보 포함으로 시스템 모니터링 및 디버깅 능력 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->