### PR TITLE
feat: instrument google places api with opentelemetry spans

### DIFF
--- a/.claude/docs/otel-instrumentation.md
+++ b/.claude/docs/otel-instrumentation.md
@@ -1,0 +1,143 @@
+# OpenTelemetry 계측 — Google Places API 호출 구간
+
+> 연관 PR: [#179](https://github.com/depromeet/ssolv-server/pull/179) · 연관 Issue: #178
+> 연관 문서: `place-recommendation-logic.md`, `place-redis-caching-strategy.md`
+
+## 왜 했나
+
+Google Places API 호출 구간은 **외부 의존성 중 가장 비싼 구간**(타임아웃 5초, 재시도 3회, 키워드당 1회 호출 × 5키워드 병렬)인데, 메트릭(카운터/히스토그램)만 있고 **개별 요청 단위의 분포/상관관계를 추적할 수 없었다**.
+
+- "P95 지연이 1.2초" → 어느 키워드? 재시도 때문? 세마포어 대기 때문?
+- "429가 2건 발생" → 동일 모임에서? 동일 키워드에서?
+- HTTP/2 전환을 고민 중이지만 **근거 데이터가 없음**
+
+Trace 는 이 질문들에 답을 준다. 그리고 이 데이터가 **HTTP/2 전환 여부의 근거**가 된다.
+
+## 무엇을 했나
+
+### 생성된 Span 계층
+
+```
+place.google.fan_out                  (키워드 5개 병렬 호출 전체 — parent)
+├── place.google.fetch                (키워드당 1개 — semaphore 포함)
+│   └── google.places.textSearch     (실제 HTTP CLIENT span)
+├── place.google.fetch
+│   └── google.places.textSearch
+└── ...
+```
+
+### Span Attributes
+
+| Span | Attribute | 용도 |
+|---|---|---|
+| `google.places.textSearch` | `google.places.query`, `google.places.radius_m`, `google.places.max_results`, `google.places.has_location_bias` | 호출 파라미터 |
+| `google.places.textSearch` | `http.status_code`, `http.protocol`, `google.places.result_count` | 응답 관측 |
+| `place.google.fetch` | `semaphore.wait_ms`, `semaphore.global.available` | 세마포어 병목 관측 |
+| `place.google.fan_out` | `place.keyword.count`, `place.selected.count`, `place.fallback.count` | 키워드 fallback 전략 관측 |
+
+### Span Events
+
+`google.places.textSearch` 에 재시도 발생 시 `retry` 이벤트 기록:
+- `retry.attempt` (1,2)
+- `retry.reason` (`ResponseException`, `TimeoutCancellationException`, ...)
+- `retry.delay_ms` (지터 포함 실제 delay)
+
+## 어떻게 동작하나
+
+### 코드 위치
+
+- [GooglePlacesClient.kt](ssolv-infrastructure/src/main/kotlin/org/depromeet/team3/place/client/GooglePlacesClient.kt) — CLIENT span + retry event
+- [ExecutePlaceSearchService.kt](ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/application/execution/ExecutePlaceSearchService.kt) — fan_out / fetch span
+
+### 코루틴 전파 패턴 (중요)
+
+```kotlin
+val tracingContext = Context.current().with(span).asContextElement()
+withContext(tracingContext) {
+    // 자식 span 은 자동으로 이 span 을 parent 로 인식
+}
+```
+
+❌ 하지 말 것: `span.makeCurrent()` — ThreadLocal 기반이라 **Dispatcher 전환 시 유실됨**
+✅ 해야 할 것: `asContextElement()` 로 코루틴 Context 에 전파
+
+### 인프라 흐름
+
+앱 → OTLP/HTTP `:4318` → Alloy (`otelcol.receiver.otlp`) → batch processor → Grafana Cloud Tempo
+
+**이미 구축되어 있었음** — [alloy-config.alloy](ssolv-infrastructure/monitoring/alloy-config.alloy) 117–145 라인.
+추가 인프라 작업 불필요. 앱에서 span 만 생성하면 됨.
+
+### 샘플링
+
+`application.yml` → `management.tracing.sampling.probability: 0.1` (10%).
+Google API 호출은 양이 많지 않으니 필요하면 0.5~1.0 으로 올려도 됨.
+
+## 어떻게 사용하나
+
+### 1) Tempo Explore 에서 직접 TraceQL
+
+**느린 호출 찾기**
+```traceql
+{ name="google.places.textSearch" && duration > 1s }
+```
+
+**특정 키워드의 호출 분포**
+```traceql
+{ span.google.places.query =~ "한식.*" }
+```
+
+**재시도 발생한 호출**
+```traceql
+{ name="google.places.textSearch" && event.name="retry" }
+```
+
+**429 Rate Limit 맞은 호출**
+```traceql
+{ span.http.status_code = 429 }
+```
+
+**세마포어에서 오래 대기한 호출**
+```traceql
+{ span.semaphore.wait_ms > 100 }
+```
+
+**모임 단위 fan-out 시간**
+```traceql
+{ name="place.google.fan_out" } | select(span.place.keyword.count, span.place.selected.count, duration)
+```
+
+### 2) Dashboard 사용
+
+`google-places-tracing.json` — Grafana Cloud 대시보드로 자동 프로비저닝됨.
+
+포함 패널:
+- **Slow Traces** — `$slow_threshold_ms` (500/1000/2000/3000/5000) 변수로 slow 기준 조절
+- **Retry Events** — 재시도 발생한 trace 목록
+- **Error Traces** — 4xx/5xx 받은 호출
+- **Fan-out** — 모임 단위 병렬 호출 요약
+- **Latency P50/P95/P99** — Tempo span-metrics generator 가 자동 생성한 메트릭 기반
+- **Call Rate by status_code** — status 분포 시계열
+
+### 3) 기존 Prometheus 대시보드와 교차 확인
+
+`google-places-api.json` (Prometheus) 와 `google-places-tracing.json` (Tempo) 는 **상호 보완**:
+
+- Prometheus 대시보드: 집계된 트렌드 (분당 호출 수, 성공률, P95)
+- Tempo 대시보드: **왜 그런지**의 근거 (어떤 키워드가 느린지, 어떤 재시도 이유가 많은지)
+
+## 배포 후 검증
+
+1. 앱 재배포 후 Grafana Cloud → Explore → Tempo
+2. `{ name="google.places.textSearch" }` 로 최근 trace 확인
+3. Span 이 보이면 성공. attribute 들이 모두 채워져 있는지 확인
+4. Service Graph (Grafana Cloud 자동 생성) 에서 `ssolv-api-core` → Google API 엣지 확인
+
+## 앞으로의 활용
+
+이 계측을 **기반**으로 다음 판단들을 데이터로 할 수 있다:
+
+- **HTTP/2 전환 판단** — `http.protocol` attribute 로 전/후 P95 비교
+- **세마포어 한도 튜닝** — `semaphore.wait_ms` 분포 보고 global/per-request 조정
+- **Circuit Breaker 도입 판단** — `event.retry.reason` 통계로 의미있는 실패 패턴 파악
+- **키워드 선택 로직 개선** — `place.fallback.count` 로 fallback 빈도 관측

--- a/ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/application/execution/ExecutePlaceSearchService.kt
+++ b/ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/application/execution/ExecutePlaceSearchService.kt
@@ -433,15 +433,21 @@ class ExecutePlaceSearchService(
         return try {
             withContext(Context.current().with(fetchSpan).asContextElement()) {
                 withTimeout(semaphoreTimeoutMs) {
+                    val requestWaitStart = System.nanoTime()
                     requestSemaphore.withPermit {
-                        val semaphoreWaitStart = System.nanoTime()
+                        val requestWaitNanos = System.nanoTime() - requestWaitStart
+                        meterRegistry.timer("google.api.semaphore.request.wait")
+                            .record(requestWaitNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
+                        fetchSpan.setAttribute("semaphore.request.wait_ms", requestWaitNanos / 1_000_000L)
+
+                        val globalWaitStart = System.nanoTime()
                         globalApiSemaphore.withPermit {
-                            val semaphoreWaitNanos = System.nanoTime() - semaphoreWaitStart
+                            val globalWaitNanos = System.nanoTime() - globalWaitStart
                             meterRegistry.timer("google.api.semaphore.wait")
-                                .record(semaphoreWaitNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
+                                .record(globalWaitNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
                             // per-request 세마포어 대기 시간을 span attribute로 기록 — aggregate metric만으로는
                             // 어떤 특정 trace가 병목이었는지 알 수 없으므로 per-trace로도 남김
-                            fetchSpan.setAttribute("semaphore.wait_ms", semaphoreWaitNanos / 1_000_000L)
+                            fetchSpan.setAttribute("semaphore.wait_ms", globalWaitNanos / 1_000_000L)
                             fetchSpan.setAttribute("semaphore.global.available", globalApiSemaphore.availablePermits.toLong())
                             withContext(dispatcher) {
                         try {

--- a/ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/application/execution/ExecutePlaceSearchService.kt
+++ b/ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/application/execution/ExecutePlaceSearchService.kt
@@ -17,6 +17,11 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.slf4j.MDCContext
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
 import org.depromeet.team3.common.GooglePlacesApiProperties
 import org.depromeet.team3.common.exception.ErrorCode
 import org.depromeet.team3.meeting.MeetingQuery
@@ -53,6 +58,7 @@ class ExecutePlaceSearchService(
 ) {
 
     private val logger = LoggerFactory.getLogger(ExecutePlaceSearchService::class.java)
+    private val tracer = GlobalOpenTelemetry.getTracer("ssolv.place.search", "1.0.0")
     private val totalFetchSize get() = googlePlacesApiProperties.totalFetchSize
     private val photoFallbackBuffer get() = googlePlacesApiProperties.photoFallbackBuffer
     private val keywordFetchSize get() = googlePlacesApiProperties.keywordFetchSize
@@ -273,23 +279,31 @@ class ExecutePlaceSearchService(
         plan: PlaceSearchPlan.Automatic,
         fallbackLimit: Int,
         dispatcher: CoroutineDispatcher
-    ): KeywordSearchResult = supervisorScope {
-        val requestSemaphore = Semaphore(googlePlacesApiProperties.requestSemaphoreSize)
-        val parentContext = currentCoroutineContext()
-        val deferredResponses = plan.keywords.map { candidate ->
-            async(parentContext + dispatcher) {
-                ensureActive()
-                runCatching {
-                    candidate to fetchPlacesFromGoogle(candidate.keyword, plan.stationCoordinates, dispatcher, requestSemaphore)
-                }.onFailure { e ->
-                    // 부모 코루틴 취소(구조화된 동시성)는 삼키지 않고 재전파
-                    if (e is CancellationException && e !is TimeoutCancellationException) throw e
-                    logger.warn("키워드 [${candidate.keyword}] 검색 중 오류 발생: ${e.message}")
-                }.getOrNull()
-            }
-        }
+    ): KeywordSearchResult {
+        val fanOutSpan = tracer.spanBuilder("place.google.fan_out")
+            .setAttribute("place.keyword.count", plan.keywords.size.toLong())
+            .setAttribute("place.fallback.limit", fallbackLimit.toLong())
+            .startSpan()
 
-        val results = deferredResponses.awaitAll().filterNotNull()
+        return try {
+            withContext(Context.current().with(fanOutSpan).asContextElement()) {
+                supervisorScope {
+                    val requestSemaphore = Semaphore(googlePlacesApiProperties.requestSemaphoreSize)
+                    val parentContext = currentCoroutineContext()
+                    val deferredResponses = plan.keywords.map { candidate ->
+                        async(parentContext + dispatcher) {
+                            ensureActive()
+                            runCatching {
+                                candidate to fetchPlacesFromGoogle(candidate.keyword, plan.stationCoordinates, dispatcher, requestSemaphore)
+                            }.onFailure { e ->
+                                // 부모 코루틴 취소(구조화된 동시성)는 삼키지 않고 재전파
+                                if (e is CancellationException && e !is TimeoutCancellationException) throw e
+                                logger.warn("키워드 [${candidate.keyword}] 검색 중 오류 발생: ${e.message}")
+                            }.getOrNull()
+                        }
+                    }
+
+                    val results = deferredResponses.awaitAll().filterNotNull()
 
         val allocations = calculateKeywordAllocations(results.map { it.first.weight }, totalFetchSize)
 
@@ -347,12 +361,25 @@ class ExecutePlaceSearchService(
             throw PlaceSearchException(ErrorCode.PLACE_NOT_FOUND)
         }
 
-        val finalPlaces = selectedPlaces.sortedWith(
-            compareByDescending<PlacesTextSearchResponse.Place> { placeWeights[it.id] ?: 0.0 }
-                .thenByDescending { it.rating ?: 0.0 }
-        ).take(totalFetchSize)
+                    val finalPlaces = selectedPlaces.sortedWith(
+                        compareByDescending<PlacesTextSearchResponse.Place> { placeWeights[it.id] ?: 0.0 }
+                            .thenByDescending { it.rating ?: 0.0 }
+                    ).take(totalFetchSize)
 
-        KeywordSearchResult(finalPlaces, fallbackCandidates.take(fallbackLimit), placeWeights, appliedKeywords.toList())
+                    fanOutSpan.setAttribute("place.selected.count", finalPlaces.size.toLong())
+                    fanOutSpan.setAttribute("place.fallback.count", fallbackCandidates.size.toLong())
+                    fanOutSpan.setAttribute("place.applied_keywords.count", appliedKeywords.size.toLong())
+
+                    KeywordSearchResult(finalPlaces, fallbackCandidates.take(fallbackLimit), placeWeights, appliedKeywords.toList())
+                }
+            }
+        } catch (e: Exception) {
+            fanOutSpan.recordException(e)
+            fanOutSpan.setStatus(StatusCode.ERROR, e.message ?: e.javaClass.simpleName)
+            throw e
+        } finally {
+            fanOutSpan.end()
+        }
     }
 
     private fun filterPlacesByKeyword(places: List<PlacesTextSearchResponse.Place>, candidate: CreateSurveyKeywordService.KeywordCandidate, overrideKeywords: Set<String>? = null): List<PlacesTextSearchResponse.Place> {
@@ -387,6 +414,12 @@ class ExecutePlaceSearchService(
         val sanitizedQuery = CreateSurveyKeywordService.normalizeKeyword(query)
         if (sanitizedQuery.isBlank()) throw PlaceSearchException(ErrorCode.PLACE_INVALID_QUERY)
 
+        val fetchSpan = tracer.spanBuilder("place.google.fetch")
+            .setSpanKind(SpanKind.INTERNAL)
+            .setAttribute("place.google.query", query)
+            .setAttribute("place.google.has_coordinates", stationCoordinates != null)
+            .startSpan()
+
         /**
          * 2-tier Semaphore 중첩 적용
          *
@@ -394,16 +427,23 @@ class ExecutePlaceSearchService(
          * [내부] globalApiSemaphore: 서버 전체 동시 호출 수 제한 (QPS 상한 방어).
          *
          * 중첩 순서: 모임별(외부) → 전역(내부)
-         * 이유: 모임방 내부 쿼터에 당첨된 요청만 전역 슬롯을 요청하도록 하여 
+         * 이유: 모임방 내부 쿼터에 당첨된 요청만 전역 슬롯을 요청하도록 하여
          *       전역 자원 기아 현상(Starvation)을 방지함.
          */
-        return withTimeout(semaphoreTimeoutMs) {
-            requestSemaphore.withPermit {
-                val semaphoreWaitStart = System.nanoTime()
-                globalApiSemaphore.withPermit {
-                    meterRegistry.timer("google.api.semaphore.wait")
-                        .record(System.nanoTime() - semaphoreWaitStart, java.util.concurrent.TimeUnit.NANOSECONDS)
-                    withContext(dispatcher) {
+        return try {
+            withContext(Context.current().with(fetchSpan).asContextElement()) {
+                withTimeout(semaphoreTimeoutMs) {
+                    requestSemaphore.withPermit {
+                        val semaphoreWaitStart = System.nanoTime()
+                        globalApiSemaphore.withPermit {
+                            val semaphoreWaitNanos = System.nanoTime() - semaphoreWaitStart
+                            meterRegistry.timer("google.api.semaphore.wait")
+                                .record(semaphoreWaitNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
+                            // per-request 세마포어 대기 시간을 span attribute로 기록 — aggregate metric만으로는
+                            // 어떤 특정 trace가 병목이었는지 알 수 없으므로 per-trace로도 남김
+                            fetchSpan.setAttribute("semaphore.wait_ms", semaphoreWaitNanos / 1_000_000L)
+                            fetchSpan.setAttribute("semaphore.global.available", globalApiSemaphore.availablePermits.toLong())
+                            withContext(dispatcher) {
                         try {
                             logger.info("Google API 검색 실행: query={}, coords=({}, {})", query, stationCoordinates?.latitude, stationCoordinates?.longitude)
                             val apiStart = System.nanoTime()
@@ -444,7 +484,15 @@ class ExecutePlaceSearchService(
             }
         }
     }
-}
+            }
+        } catch (e: Exception) {
+            fetchSpan.recordException(e)
+            fetchSpan.setStatus(StatusCode.ERROR, e.message ?: e.javaClass.simpleName)
+            throw e
+        } finally {
+            fetchSpan.end()
+        }
+    }
 
     private fun recordMetric(result: String) {
         meterRegistry.counter("google.api.call.count", listOf(Tag.of("result", result))).increment()

--- a/ssolv-infrastructure/monitoring/grafana/provisioning/dashboards/google-places-tracing.json
+++ b/ssolv-infrastructure/monitoring/grafana/provisioning/dashboards/google-places-tracing.json
@@ -1,0 +1,193 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_TEMPO",
+      "label": "Tempo",
+      "description": "Grafana Cloud Tempo",
+      "type": "datasource",
+      "pluginId": "tempo",
+      "pluginName": "Tempo"
+    },
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Grafana Cloud Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "datasource", "id": "tempo", "name": "Tempo", "version": "1.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "title": "Google Places API — Tracing",
+  "uid": "google-places-tracing",
+  "tags": ["ssolv", "google", "places", "tracing"],
+  "timezone": "Asia/Seoul",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "slow_threshold_ms",
+        "type": "custom",
+        "label": "Slow Threshold (ms)",
+        "query": "500,1000,2000,3000,5000",
+        "current": { "text": "1000", "value": "1000" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Trace Explore (Tempo)",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "table",
+      "title": "Slow Traces — google.places.textSearch",
+      "description": "duration > ${slow_threshold_ms}ms 인 호출 TraceID 목록. 행 클릭 → Tempo 탐색으로 이동",
+      "datasource": { "type": "tempo", "uid": "${DS_TEMPO}" },
+      "gridPos": { "x": 0, "y": 1, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ name=\"google.places.textSearch\" && duration > ${slow_threshold_ms}ms } | select(span.google.places.query, span.http.status_code, span.google.places.result_count)",
+          "limit": 50,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Retry Events — 재시도 발생 trace",
+      "description": "재시도가 발생한 호출들. event.retry.reason / event.retry.attempt 확인",
+      "datasource": { "type": "tempo", "uid": "${DS_TEMPO}" },
+      "gridPos": { "x": 0, "y": 11, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ name=\"google.places.textSearch\" && event.name=\"retry\" }",
+          "limit": 50,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Error Traces — 4xx / 5xx 응답",
+      "description": "HTTP 4xx/5xx 를 받은 Google API 호출",
+      "datasource": { "type": "tempo", "uid": "${DS_TEMPO}" },
+      "gridPos": { "x": 0, "y": 21, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ name=\"google.places.textSearch\" && span.http.status_code >= 400 }",
+          "limit": 50,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Fan-out — 키워드 5개 병렬 호출",
+      "description": "모임 단위 place.google.fan_out span. keyword/selected/fallback 개수 한눈에 확인",
+      "datasource": { "type": "tempo", "uid": "${DS_TEMPO}" },
+      "gridPos": { "x": 0, "y": 31, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "traceql",
+          "query": "{ name=\"place.google.fan_out\" } | select(span.place.keyword.count, span.place.selected.count, span.place.fallback.count, span.place.applied_keywords.count)",
+          "limit": 50,
+          "tableType": "traces"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Span Metrics (Tempo → Prometheus)",
+      "gridPos": { "x": 0, "y": 41, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency P95 — google.places.textSearch",
+      "description": "Grafana Cloud Tempo 의 span metrics generator 로부터 산출. HTTP/2 전환 전/후 비교용 baseline",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 42, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"google.places.textSearch\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"google.places.textSearch\"}[5m])))",
+          "legendFormat": "p99"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"google.places.textSearch\"}[5m])))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Call Rate by status_code",
+      "description": "HTTP 응답 코드별 호출 비율",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 42, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (status_code) (rate(traces_spanmetrics_calls_total{span_name=\"google.places.textSearch\"}[5m]))",
+          "legendFormat": "{{status_code}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency P95 — place.google.fetch (Semaphore 포함)",
+      "description": "세마포어 대기 + Google 호출 전체 시간. semaphore.wait_ms attribute 와 교차 확인",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 0, "y": 50, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"place.google.fetch\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"place.google.fetch\"}[5m])))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency P95 — place.google.fan_out (Fan-out 전체)",
+      "description": "키워드 5개 병렬 처리 전체 시간. 꼬리 지연(tail latency)은 여기서 드러남",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "x": 12, "y": 50, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"place.google.fan_out\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(traces_spanmetrics_latency_bucket{span_name=\"place.google.fan_out\"}[5m])))",
+          "legendFormat": "p50"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    }
+  ],
+  "schemaVersion": 39,
+  "version": 1
+}

--- a/ssolv-infrastructure/src/main/kotlin/org/depromeet/team3/place/client/GooglePlacesClient.kt
+++ b/ssolv-infrastructure/src/main/kotlin/org/depromeet/team3/place/client/GooglePlacesClient.kt
@@ -2,8 +2,17 @@ package org.depromeet.team3.place.client
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.depromeet.team3.common.GooglePlacesApiProperties
 import org.depromeet.team3.common.exception.ErrorCode
@@ -28,13 +37,14 @@ class GooglePlacesClient(
 ) {
 
     private val logger = KotlinLogging.logger { GooglePlacesClient::class.java.name }
-    
+    private val tracer = GlobalOpenTelemetry.getTracer("ssolv.place.google", "1.0.0")
+
     // API 호출 타임아웃 설정 (5초)
     private val apiTimeoutMillis = 5_000L
-    
+
     // 재시도 설정
     private val maxRetries = 3  // 최대 3번 시도 (초기 1번 + 재시도 2번)
-    private val initialDelayMillis = 100L 
+    private val initialDelayMillis = 100L
     private val maxDelayMillis = 2000L
     private val jitterMaxMillis = 100L
 
@@ -75,6 +85,15 @@ class GooglePlacesClient(
                     if (e is ResponseException && e.response.status.value == 429) {
                         meterRegistry.counter("google.api.rate_limit.hit").increment()
                     }
+                    // trace에 재시도 이벤트 기록 — per-request 재시도 패턴 분석용
+                    Span.current().addEvent(
+                        "retry",
+                        Attributes.of(
+                            AttributeKey.longKey("retry.attempt"), (attempt + 1).toLong(),
+                            AttributeKey.stringKey("retry.reason"), e.javaClass.simpleName,
+                            AttributeKey.longKey("retry.delay_ms"), totalDelay
+                        )
+                    )
                     delay(totalDelay)
                     delayMillis = minOf(delayMillis * 2, maxDelayMillis)
                 } else {
@@ -94,64 +113,88 @@ class GooglePlacesClient(
      * 텍스트 검색 (Ktor 버전)
      */
     suspend fun textSearch(
-        query: String, 
+        query: String,
         maxResults: Int = 10,
         latitude: Double? = null,
         longitude: Double? = null,
         radius: Double = 3000.0
     ): PlacesTextSearchResponse {
+        val span = tracer.spanBuilder("google.places.textSearch")
+            .setSpanKind(SpanKind.CLIENT)
+            .setAttribute("google.places.query", query)
+            .setAttribute("google.places.max_results", maxResults.toLong())
+            .setAttribute("google.places.radius_m", radius)
+            .setAttribute("google.places.has_location_bias", latitude != null && longitude != null)
+            .startSpan()
 
-        
-        return retryWithExponentialBackoff(
-            operation = "텍스트 검색",
-            operationDetail = "query=$query"
-        ) {
-            try {
-                withTimeout(apiTimeoutMillis) {
-                    val locationBias = if (latitude != null && longitude != null) {
-                        PlacesTextSearchRequest.LocationBias(
-                            circle = PlacesTextSearchRequest.Circle(
-                                center = PlacesTextSearchRequest.Circle.Center(
-                                    latitude = latitude,
-                                    longitude = longitude
-                                ),
-                                radius = radius
+        // 코루틴에서는 Context를 코루틴 ContextElement로 전달해야 스레드 전환에도 유지됨
+        val tracingContext = Context.current().with(span).asContextElement()
+
+        return try {
+            withContext(tracingContext) {
+                retryWithExponentialBackoff(
+                    operation = "텍스트 검색",
+                    operationDetail = "query=$query"
+                ) {
+                    try {
+                        withTimeout(apiTimeoutMillis) {
+                            val locationBias = if (latitude != null && longitude != null) {
+                                PlacesTextSearchRequest.LocationBias(
+                                    circle = PlacesTextSearchRequest.Circle(
+                                        center = PlacesTextSearchRequest.Circle.Center(
+                                            latitude = latitude,
+                                            longitude = longitude
+                                        ),
+                                        radius = radius
+                                    )
+                                )
+                            } else null
+
+                            val request = PlacesTextSearchRequest(
+                                textQuery = query,
+                                languageCode = "ko",
+                                maxResultCount = maxResults,
+                                locationBias = locationBias
                             )
+
+                            val response = httpClient.post("${googlePlacesApiProperties.baseUrl}/v1/places:searchText") {
+                                header("X-Goog-Api-Key", googlePlacesApiProperties.apiKey)
+                                header("X-Goog-FieldMask", buildTextSearchFieldMask())
+                                contentType(ContentType.Application.Json)
+                                setBody(request)
+                            }
+                            span.setAttribute("http.status_code", response.status.value.toLong())
+                            span.setAttribute("http.protocol", response.version.toString())
+                            response.body<PlacesTextSearchResponse>().also { parsed ->
+                                span.setAttribute("google.places.result_count", (parsed.places?.size ?: 0).toLong())
+                            }
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        logger.error(e) { "Google Places API 텍스트 검색 타임아웃: query=$query" }
+                        throw PlaceSearchException(
+                            ErrorCode.PLACE_API_ERROR,
+                            detail = mapOf("query" to query, "error" to "요청 타임아웃 (${apiTimeoutMillis}ms 초과)")
                         )
-                    } else null
-
-                    val request = PlacesTextSearchRequest(
-                        textQuery = query,
-                        languageCode = "ko",
-                        maxResultCount = maxResults,
-                        locationBias = locationBias
-                    )
-
-                    httpClient.post("${googlePlacesApiProperties.baseUrl}/v1/places:searchText") {
-                        header("X-Goog-Api-Key", googlePlacesApiProperties.apiKey)
-                        header("X-Goog-FieldMask", buildTextSearchFieldMask())
-                        contentType(ContentType.Application.Json)
-                        setBody(request)
-                    }.body<PlacesTextSearchResponse>()
+                    } catch (e: Exception) {
+                        if (e is ResponseException) {
+                            val body = e.response.body<String>()
+                            logger.error { "Google Places API 오류 (${e.response.status}): $body" }
+                            throw PlaceSearchException(
+                                ErrorCode.PLACE_API_ERROR,
+                                detail = mapOf("statusCode" to e.response.status.value, "body" to body)
+                            )
+                        }
+                        if (e is PlaceSearchException) throw e
+                        throw e
+                    }
                 }
-            } catch (e: TimeoutCancellationException) {
-                logger.error(e) { "Google Places API 텍스트 검색 타임아웃: query=$query" }
-                throw PlaceSearchException(
-                    ErrorCode.PLACE_API_ERROR,
-                    detail = mapOf("query" to query, "error" to "요청 타임아웃 (${apiTimeoutMillis}ms 초과)")
-                )
-            } catch (e: Exception) {
-                if (e is ResponseException) {
-                    val body = e.response.body<String>()
-                    logger.error { "Google Places API 오류 (${e.response.status}): $body" }
-                    throw PlaceSearchException(
-                        ErrorCode.PLACE_API_ERROR,
-                        detail = mapOf("statusCode" to e.response.status.value, "body" to body)
-                    )
-                }
-                if (e is PlaceSearchException) throw e
-                throw e
             }
+        } catch (e: Exception) {
+            span.recordException(e)
+            span.setStatus(StatusCode.ERROR, e.message ?: e.javaClass.simpleName)
+            throw e
+        } finally {
+            span.end()
         }
     }
 

--- a/ssolv-infrastructure/src/main/kotlin/org/depromeet/team3/place/client/GooglePlacesClient.kt
+++ b/ssolv-infrastructure/src/main/kotlin/org/depromeet/team3/place/client/GooglePlacesClient.kt
@@ -136,59 +136,60 @@ class GooglePlacesClient(
                     operation = "텍스트 검색",
                     operationDetail = "query=$query"
                 ) {
-                    try {
-                        withTimeout(apiTimeoutMillis) {
-                            val locationBias = if (latitude != null && longitude != null) {
-                                PlacesTextSearchRequest.LocationBias(
-                                    circle = PlacesTextSearchRequest.Circle(
-                                        center = PlacesTextSearchRequest.Circle.Center(
-                                            latitude = latitude,
-                                            longitude = longitude
-                                        ),
-                                        radius = radius
-                                    )
+                    // raw 예외(ResponseException / TimeoutCancellationException 등)를 그대로 전파해야
+                    // retryWithExponentialBackoff 가 5xx/429/타임아웃을 retryable 로 판정할 수 있음.
+                    // PlaceSearchException 변환은 retry 루프가 끝난 뒤 바깥 catch 에서 수행.
+                    withTimeout(apiTimeoutMillis) {
+                        val locationBias = if (latitude != null && longitude != null) {
+                            PlacesTextSearchRequest.LocationBias(
+                                circle = PlacesTextSearchRequest.Circle(
+                                    center = PlacesTextSearchRequest.Circle.Center(
+                                        latitude = latitude,
+                                        longitude = longitude
+                                    ),
+                                    radius = radius
                                 )
-                            } else null
-
-                            val request = PlacesTextSearchRequest(
-                                textQuery = query,
-                                languageCode = "ko",
-                                maxResultCount = maxResults,
-                                locationBias = locationBias
                             )
+                        } else null
 
-                            val response = httpClient.post("${googlePlacesApiProperties.baseUrl}/v1/places:searchText") {
-                                header("X-Goog-Api-Key", googlePlacesApiProperties.apiKey)
-                                header("X-Goog-FieldMask", buildTextSearchFieldMask())
-                                contentType(ContentType.Application.Json)
-                                setBody(request)
-                            }
-                            span.setAttribute("http.status_code", response.status.value.toLong())
-                            span.setAttribute("http.protocol", response.version.toString())
-                            response.body<PlacesTextSearchResponse>().also { parsed ->
-                                span.setAttribute("google.places.result_count", (parsed.places?.size ?: 0).toLong())
-                            }
-                        }
-                    } catch (e: TimeoutCancellationException) {
-                        logger.error(e) { "Google Places API 텍스트 검색 타임아웃: query=$query" }
-                        throw PlaceSearchException(
-                            ErrorCode.PLACE_API_ERROR,
-                            detail = mapOf("query" to query, "error" to "요청 타임아웃 (${apiTimeoutMillis}ms 초과)")
+                        val request = PlacesTextSearchRequest(
+                            textQuery = query,
+                            languageCode = "ko",
+                            maxResultCount = maxResults,
+                            locationBias = locationBias
                         )
-                    } catch (e: Exception) {
-                        if (e is ResponseException) {
-                            val body = e.response.body<String>()
-                            logger.error { "Google Places API 오류 (${e.response.status}): $body" }
-                            throw PlaceSearchException(
-                                ErrorCode.PLACE_API_ERROR,
-                                detail = mapOf("statusCode" to e.response.status.value, "body" to body)
-                            )
+
+                        val response = httpClient.post("${googlePlacesApiProperties.baseUrl}/v1/places:searchText") {
+                            header("X-Goog-Api-Key", googlePlacesApiProperties.apiKey)
+                            header("X-Goog-FieldMask", buildTextSearchFieldMask())
+                            contentType(ContentType.Application.Json)
+                            setBody(request)
                         }
-                        if (e is PlaceSearchException) throw e
-                        throw e
+                        span.setAttribute("http.status_code", response.status.value.toLong())
+                        span.setAttribute("http.protocol", response.version.toString())
+                        response.body<PlacesTextSearchResponse>().also { parsed ->
+                            span.setAttribute("google.places.result_count", (parsed.places?.size ?: 0).toLong())
+                        }
                     }
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            span.recordException(e)
+            span.setStatus(StatusCode.ERROR, "timeout")
+            logger.error(e) { "Google Places API 텍스트 검색 타임아웃: query=$query" }
+            throw PlaceSearchException(
+                ErrorCode.PLACE_API_ERROR,
+                detail = mapOf("query" to query, "error" to "요청 타임아웃 (${apiTimeoutMillis}ms 초과)")
+            )
+        } catch (e: ResponseException) {
+            val body = e.response.body<String>()
+            span.recordException(e)
+            span.setStatus(StatusCode.ERROR, "http ${e.response.status.value}")
+            logger.error { "Google Places API 오류 (${e.response.status}): $body" }
+            throw PlaceSearchException(
+                ErrorCode.PLACE_API_ERROR,
+                detail = mapOf("statusCode" to e.response.status.value, "body" to body)
+            )
         } catch (e: Exception) {
             span.recordException(e)
             span.setStatus(StatusCode.ERROR, e.message ?: e.javaClass.simpleName)


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- closes #178

## 🔑 주요 내용

- Google Places API 호출 구간에 OpenTelemetry span 수동 계측 추가
- `GooglePlacesClient.textSearch`를 CLIENT span으로 감싸고 query, radius, result_count, http.status_code, http.protocol 속성 기록
- 재시도를 span event로 기록 (attempt, reason, delay_ms)
- `ExecutePlaceSearchService.fetchPlacesForKeywords`에 fan-out 부모 span, `fetchPlacesFromGoogle`에 개별 호출 span 추가
- Semaphore 대기 시간을 span attribute로 기록 (aggregate metric으로는 알 수 없는 per-trace 병목 분석 가능)
- 코루틴 dispatcher 전환에 안전한 `asContextElement()` 기반 context 전파 사용 

## 왜 필요한가

현재 `ExecutePlaceSearchService.execute` 내부 5초대 구간이 trace상 블랙홀이라, 어디가 진짜 병목인지 데이터로 확인할 방법이 없음. HTTP/2 전환, Circuit Breaker 도입 등 후속 개선을 flame graph 기반으로 판단하기 위한 baseline 확보가 목적.


## Check List

- [x] Assignees 등록을 하였나요?
- [x] 라벨(Label) 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 및 모니터링 개선**
  * 장소 검색 서비스의 성능 추적 및 진단 기능 강화
  * Google Places API 통합의 상세한 실행 메트릭 및 오류 추적 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->