### PR TITLE
feat: add /retro command and compounding retrospective loop

### DIFF
--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,0 +1,160 @@
+---
+description: Session retrospective — extract learnings from current conversation and distribute them into memory, CLAUDE.md, thoughts/retros, thoughts/learning, and skills. Core engine of Compounding Engineering loop. Invoke at session end or major milestones.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, ToolSearch
+argument-hint: "[optional: focus area, e.g. 'infra' or 'frontend-pain']"
+---
+
+# /retro — 세션 회고 루프
+
+## 목적
+
+이번 세션에서 드러난 사용자·조직·프로젝트 사실, 업무 스타일, 프롬프팅 습관, 지식 공백, 반복 패턴을 추출해 **컴파운딩 인프라에 축적**합니다. 다음 세션이 더 빠르게 시작되도록.
+
+> Bootstrapping + Compounding 엔진입니다. 매 세션 종료 또는 큰 마일스톤 완료 시점에 실행하세요.
+
+---
+
+## 실행 흐름
+
+### 1단계. 추출 (Claude가 자동)
+
+현재 세션 transcript를 훑어 **5가지 항목 후보**를 뽑습니다. 각 후보는 "세션에서 실제로 드러난 증거(발화·행동)"가 있어야 합니다.
+
+| # | 항목 | 추출 기준 |
+|---|---|---|
+| 1 | 사용자/조직/프로젝트 사실 | 코드·git으로 알 수 없는 것만 (팀 구성, 마감일, 외부 제약, 개인 역할·책임) |
+| 2 | 업무 스타일 · 협업 방식 | 반복된 지시 패턴, 선호 응답 길이, 의사결정 스타일, 호출 주기 |
+| 3 | 프롬프팅 습관 관찰 | 자주 누락되는 맥락, 불명확했던 요청, 개선 여지 |
+| 4 | 학습자료 후보 | 사용자가 모른다고 한 영역, Claude가 설명을 길게 해야 했던 주제 |
+| 5 | 스킬 갭 | `find-skills` 실행 후 이번 세션 주제에 맞는 외부 skill 존재 여부. 없으면 신규 skill 필요 |
+
+**추출 규칙:**
+- 저 세션이 아닌 **이번 세션**에서 드러난 것만.
+- "확실하지 않으면 후보에 올리지 말 것" — 사용자를 피곤하게 만들지 않는다.
+- 같은 항목이 이미 memory에 있으면 **업데이트 후보**로 표시.
+
+---
+
+### 2단계. 사용자 확인 (대화형)
+
+각 후보를 한 항목씩 보여주며 **승인받습니다**:
+
+```
+## 추출 결과 — 후보 N개
+
+### 1. 사용자/조직/프로젝트 사실
+- [a] ssolv는 Depromeet 17기 팀 프로젝트이고 박민음이 백엔드 단독 주도 중
+- [b] PR #182가 방금 dev에 머지됨 — Phase 1.5 완료
+...
+
+각 항목을 저장할까요? (a/b/c... 또는 "전부" / "skip")
+```
+
+**승인받은 것만** 3단계로. skip된 건 **회고록에만** 기록(노이즈 필터 로그 용도).
+
+---
+
+### 3단계. 저장 (승인된 것만)
+
+| 항목 | 저장 위치 | 방식 |
+|---|---|---|
+| 1. 사실 | `~/.claude/projects/-Users-parkmineum-17th-team3-Server/memory/{user,project,reference}_*.md` | frontmatter 포함 파일 생성 + `MEMORY.md` 인덱스 한 줄 추가 |
+| 2. 업무 스타일 (팀 공유) | `CLAUDE.md` | **diff 제안만** → 사용자 승인 → Edit |
+| 2. 업무 스타일 (개인용) | `CLAUDE.local.md` | 직접 Edit 가능 |
+| 3. 프롬프팅 습관 | `thoughts/retros/YYYY-MM-DD.md` | 날짜별 회고록 (같은 날 2회 이상이면 append) |
+| 4. 학습자료 | `thoughts/learning/resources.md` | 카테고리별 append. 이유 한 줄 + 날짜 필수 |
+| 5a. find-skills 매칭 성공 | 회고록에 참조 기록 | Skill 호출만 |
+| 5b. 신규 skill 필요 | `skill-creator` 자동 호출 → `.claude/skills/<new-name>/SKILL.md` | **자동 생성** (frontmatter 포함) |
+
+#### 저장 세부 규칙
+
+**Memory 파일 포맷** (항목 1):
+```markdown
+---
+name: <짧은 이름>
+description: <한 줄 — 미래 매칭용>
+type: user | project | reference | feedback
+---
+
+<본문>
+```
+생성 후 `MEMORY.md`에 `- [제목](파일명.md) — 한 줄 요약` 추가.
+
+**CLAUDE.md 편집 원칙** (항목 2 — 팀 공유):
+- 자동 write 금지.
+- diff 형태로 출력 → "적용해주세요" 응답 받은 경우에만 Edit 실행.
+- 섹션 중복 금지 — 기존 섹션 업데이트 우선.
+
+**thoughts/retros/ 회고록 포맷**:
+```markdown
+# Retro — YYYY-MM-DD
+
+## 세션 요약
+<1~2줄>
+
+## 이번 세션에서 쌓인 것
+- Memory: ...
+- Skills: ...
+- Learning links: ...
+- CLAUDE.md 제안: ...
+
+## 프롬프팅 습관 관찰
+- <개선점 N>: <근거 발화·행동>
+
+## 다음 세션 시작 시 참고
+- <있으면>
+
+## Skipped candidates (노이즈 로그)
+- <사용자가 저장 거부한 후보들 — 같은 것 또 뽑지 않도록>
+```
+
+**skill-creator 사용** (항목 5b):
+- `Skill` 도구로 `anthropic-skills:skill-creator` 호출
+- 프로젝트 맥락 전달: "ssolv, Kotlin/Spring Boot 3, 이번 세션 주제 = ..."
+- 생성 위치는 `.claude/skills/<name>/SKILL.md`
+- frontmatter에 `name` + `description` 필수
+
+---
+
+### 4단계. 마무리 보고
+
+```
+## /retro 완료
+
+- Memory: +N개
+  - user_xxx.md
+  - project_yyy.md
+- CLAUDE.md 제안: N건 (승인 대기 중)
+- thoughts/retros/YYYY-MM-DD.md: 기록 완료
+- thoughts/learning/resources.md: +N개 링크 추가
+- Skills: +N개 생성 (이름 목록)
+- Skipped: N건 (회고록에 로그)
+
+다음 세션 시작 시: 이 회고록을 먼저 참조하도록 Claude에게 안내할지 제안합니다.
+```
+
+---
+
+## Claude에게 — 세션 중 리마인더 기준
+
+다음 신호가 감지되면 **사용자에게 `/retro` 실행을 제안**하세요:
+
+- 큰 마일스톤 완료 직후 (PR 머지, 기능 완성, 배포)
+- 사용자 교정이 세션 내 3회 이상 반복 (패턴 축적 필요)
+- 세션이 길어져 토픽이 명확히 전환될 때
+- 사용자가 "다음에 이어서", "오늘 여기까지" 류 마무리 발화를 할 때
+- `/context`가 50% 이상 차올랐을 때
+
+제안 문구 예: **"지금 `/retro` 한 번 돌릴 타이밍 같은데, 돌릴까요?"**
+
+강제 호출 금지. 사용자가 "ㄴㄴ" 하면 계속 진행.
+
+---
+
+## 금지 사항
+
+- ❌ 민감 정보(SSH 키 경로, 토큰, 개인 경로)를 `thoughts/`·커밋 대상 memory에 저장 금지 → `CLAUDE.local.md`에만.
+- ❌ 확신 없는 후보를 사용자 확인 없이 저장.
+- ❌ `CLAUDE.md`에 자동 write (항상 diff 제안 → 승인 후 Edit).
+- ❌ 동일 항목을 매 세션 중복 저장 (memory 기존 항목 체크 후 업데이트 우선).
+- ❌ 회고록을 너무 길게 (5~15줄 요약 수준, 대화 transcript 복붙 금지).

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -66,6 +66,21 @@ argument-hint: "[optional: focus area, e.g. 'infra' or 'frontend-pain']"
 | 5a. find-skills 매칭 성공 | 회고록에 참조 기록 | Skill 호출만 |
 | 5b. 신규 skill 필요 | `skill-creator` 자동 호출 → `.claude/skills/<new-name>/SKILL.md` | **자동 생성** (frontmatter 포함) |
 
+#### 저장 전 필수 — CLAUDE.md 충돌 점검
+
+memory·skills와 `CLAUDE.md`의 규칙이 시간이 지나면서 드리프트할 수 있습니다. **각 저장 후보를 확정하기 직전에 `CLAUDE.md` (및 `CLAUDE.local.md`) 규칙과 의미적 충돌이 없는지 확인**하세요.
+
+예시 충돌:
+- memory 후보: *"사용자가 커밋을 한국어로 쓰는 걸 선호함"*
+- `CLAUDE.md` 규칙: *"Commit messages: 영문만"*
+
+충돌 감지 시 사용자에게 **두 갈래 선택지**를 제시합니다:
+
+1. **후보 폐기** — memory 저장 취소 (과거 규칙이 여전히 유효한 경우)
+2. **`CLAUDE.md` 업데이트** — 규칙 자체가 낡은 경우. diff 제안 후 **(d) 원칙**(승인→Edit)에 따라 처리.
+
+충돌이 없다고 판단될 때만 아래 저장 세부 규칙으로 진행하세요.
+
 #### 저장 세부 규칙
 
 **Memory 파일 포맷** (항목 1):

--- a/.claude/docs/compounding-engineering.md
+++ b/.claude/docs/compounding-engineering.md
@@ -110,3 +110,41 @@ skill: 어느 스킬에 반영했는가 (없으면 새 스킬 필요)
 - [ ] 자주 SSH 접속하는 패턴이 있는가? → commands로 추상화
 - [ ] 같은 hook 오류가 반복되는가? → hook 조건 개선
 - [ ] 새 도메인이 추가됐는가? → 해당 skill 필요한지 검토
+
+---
+
+## 2026-04-21 Phase 2: 회고 루프 도입
+
+### 배경
+- Phase 1 ([PR #181](https://github.com/depromeet/ssolv-server/pull/181)): harness + 기본 인프라
+- Phase 1.5 ([PR #182](https://github.com/depromeet/ssolv-server/pull/182)): frontmatter 기반 auto-discovery
+
+여기까지는 "쌓이는 인프라(뼈대)"를 준비한 단계. 하지만 **세션이 끝나면 관찰이 휘발**되는 구조 — 매 세션 교정·발견이 다음 세션에 전달되지 않음.
+
+Phase 2는 **세션 회고 루프**를 추가해, 매 세션 종료 시 관찰이 memory / CLAUDE.md / thoughts/ / skills로 분배되도록 한다. 이로써 다음 세션은 "맨땅"이 아니라 "축적된 컨텍스트 위"에서 시작된다.
+
+### 추가된 것
+- `.claude/commands/retro.md` — 세션 회고 엔진
+- `thoughts/retros/` — 세션별 회고록 (git 커밋)
+- `thoughts/learning/resources.md` — 학습자료 누적 허브 (git 커밋)
+- `CLAUDE.local.md` — 민감 정보(SSH 키, 인스턴스 IP, RDS 엔드포인트) 분리 (git-ignored)
+- `CLAUDE.md` 정리 — 팀 공유 규칙만 남고 민감 정보는 로컬 파일 참조로 변경
+- `.gitignore` — `CLAUDE.local.md` 추가
+
+### 실행 원칙 (결정사항)
+
+Phase 2 설계 시 4가지 결정사항을 사용자와 합의했다:
+
+- **(a) `thoughts/` git 커밋함.** 팀 공유 + 미래 본인에게 공유. 민감 내용은 어차피 `CLAUDE.local.md` / memory로 분리되므로 회고록에 쓰이지 않음.
+- **(b) `/retro`는 수동 호출 + Claude가 세션 중 리마인드 제안.** 자동 Stop hook은 노이즈 누적 위험이 커서 보류. 대신 리마인더 기준을 커맨드 문서에 명시.
+- **(c) 신규 skill은 `skill-creator`로 자동 생성.** `find-skills`가 빈 결과 반환하면 바로 초안 생성. 이름·description은 사용자 확인 후.
+- **(d) `CLAUDE.md` 수정은 diff 제안 → 사용자 승인 → Edit.** 팀 공유 파일이므로 자동 쓰기 금지. `CLAUDE.local.md`는 직접 Edit 허용.
+
+### 참고자료
+- [진정한 Claude Code 사용법 — Dr. Dan](https://babelai.tistory.com/42): 4단계 워크플로(research/plan/implement/validate) + `thoughts/` 구조 제안. 이 프로젝트엔 **회고 루프만 선별 도입**. 이유: token 비용, ssolv 규모 대비 4단계 워크플로는 오버킬. 필요 시 Phase 3에서 대형 작업 전용으로 재검토.
+- humanlayer 방식의 `thoughts/{personal,shared,searchable}` 3-tier는 도입 안 함 (팀 2~3명에 과잉 구조).
+
+### 다음 Phase 후보 (미정 · 필요 시 재검토)
+- **Phase 3-a**: 세션 간 retro 상호 참조 — 누적된 회고록을 분석해 "반복된 실수 Top N" 추출 후 skill 고도화
+- **Phase 3-b**: Plan 기반 워크플로 선별 도입 — 대형 리팩터링/신규 도메인 추가 시 research→plan→implement→validate 4단계 적용
+- **Phase 3-c**: 커스텀 sub-agent 도입 — 현재는 built-in Explore로 충분하다 판단, 보류

--- a/.claude/docs/compounding-engineering.md
+++ b/.claude/docs/compounding-engineering.md
@@ -124,7 +124,9 @@ skill: 어느 스킬에 반영했는가 (없으면 새 스킬 필요)
 Phase 2는 **세션 회고 루프**를 추가해, 매 세션 종료 시 관찰이 memory / CLAUDE.md / thoughts/ / skills로 분배되도록 한다. 이로써 다음 세션은 "맨땅"이 아니라 "축적된 컨텍스트 위"에서 시작된다.
 
 ### 추가된 것
-- `.claude/commands/retro.md` — 세션 회고 엔진
+- `.claude/commands/retro.md` — 세션 회고 엔진 (`#### 저장 전 필수 — CLAUDE.md 충돌 점검` 서브섹션 포함)
+- `.claude/hooks/post-push-retro-nudge.sh` — `git push` 성공 후 `/retro` 리마인더 (노이즈 적은 stdout 메시지)
+- `.claude/settings.json` — PostToolUse(Bash)에 위 hook 등록
 - `thoughts/retros/` — 세션별 회고록 (git 커밋)
 - `thoughts/learning/resources.md` — 학습자료 누적 허브 (git 커밋)
 - `CLAUDE.local.md` — 민감 정보(SSH 키, 인스턴스 IP, RDS 엔드포인트) 분리 (git-ignored)
@@ -147,4 +149,6 @@ Phase 2 설계 시 4가지 결정사항을 사용자와 합의했다:
 ### 다음 Phase 후보 (미정 · 필요 시 재검토)
 - **Phase 3-a**: 세션 간 retro 상호 참조 — 누적된 회고록을 분석해 "반복된 실수 Top N" 추출 후 skill 고도화
 - **Phase 3-b**: Plan 기반 워크플로 선별 도입 — 대형 리팩터링/신규 도메인 추가 시 research→plan→implement→validate 4단계 적용
-- **Phase 3-c**: 커스텀 sub-agent 도입 — 현재는 built-in Explore로 충분하다 판단, 보류
+- **Phase 3-c**: 세션 시작 시 선제 `/retro` 제안 — 마지막 실행 시각 + 커밋 누적을 상태 파일로 추적. 현재는 push 후 hook 리마인더만으로 충분 판단, 보류.
+- **Phase 3-d**: memory ↔ `CLAUDE.md` 충돌 자동 감지 Hook — 현재는 `/retro` 내부 저장 단계에서 수동 점검. 충돌 사례가 쌓이면 LLM hook으로 승격 검토.
+- **Phase 3-e**: 커스텀 sub-agent 도입 — 현재는 built-in Explore로 충분하다 판단, 보류.

--- a/.claude/hooks/post-push-retro-nudge.sh
+++ b/.claude/hooks/post-push-retro-nudge.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# /retro 리마인더 Hook
+# PostToolUse(Bash): git push 명령이 성공적으로 완료된 후 /retro 실행을 권유.
+# Phase 2 컴파운딩 루프의 (b) 결정사항 — "수동 호출 + 리마인드"
+
+TOOL_INPUT=$(cat)
+
+# Bash 명령어 및 exit code 추출
+PARSED=$(echo "$TOOL_INPUT" | python3 -c "
+import sys, json, shlex
+try:
+    d = json.load(sys.stdin)
+    cmd = d.get('tool_input', {}).get('command', '')
+    response = d.get('tool_response', {}) or d.get('tool_output', {})
+    exit_code = response.get('exit_code', response.get('returncode', 0))
+    try:
+        tokens = shlex.split(cmd)
+    except ValueError:
+        tokens = cmd.split()
+    # git push 인지 확인 (subcommand 위치: argv[0..1])
+    is_push = len(tokens) >= 2 and tokens[0] == 'git' and tokens[1] == 'push'
+    # --delete / --dry-run 제외 (실제 배포/반영이 아닌 경우)
+    excluded = any(flag in tokens for flag in ['--delete', '-d', '--dry-run', '-n'])
+    print('push' if (is_push and not excluded) else 'skip')
+    print(exit_code)
+except Exception:
+    print('skip')
+    print(1)
+" 2>/dev/null)
+
+IS_PUSH=$(echo "$PARSED" | sed -n '1p')
+EXIT_CODE=$(echo "$PARSED" | sed -n '2p')
+
+# git push 가 아니면 종료
+if [[ "$IS_PUSH" != "push" ]]; then
+    exit 0
+fi
+
+# push 실패 시 종료 (실패는 다른 hook/CI가 처리)
+if [[ "$EXIT_CODE" != "0" ]]; then
+    exit 0
+fi
+
+# 사용자에게 리마인더 출력 (Claude도 이 메시지를 볼 수 있음)
+cat <<'EOF'
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+💡 Push 완료 — /retro 돌릴 타이밍입니다
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+이번 작업에서 드러난 사용자·조직·프로젝트 사실, 반복된 교정,
+발견된 스킬 갭을 memory / CLAUDE.md / thoughts/ 로 축적하려면
+  → /retro
+  (수동 호출입니다. 돌리지 않아도 됩니다.)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,16 @@
             "timeout": 15000
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-push-retro-nudge.sh\"",
+            "timeout": 5000
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ ssolv-api-place/src/main/kotlin/org/depromeet/team3/place/controller/BenchmarkCo
 # K6 부하 테스트
 k6/
 *.html
+
+# Claude Code personal overrides (credentials, local paths)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,40 +98,9 @@ Cases that require manual follow-up:
 
 ## Production Server SSH Access
 
-For production operations (checking server status, restarting containers, reading logs, editing `.env`, etc.), **SSH in directly without asking the user**.
+실제 접속 자격증명(SSH 키 경로, 인스턴스 Public/Private IP, RDS 엔드포인트, 공통 SSH 명령 예시)은 **`CLAUDE.local.md`** 에 있습니다 — 개인 전용, git-ignored.
 
-```
-SSH Key  : /Users/parkmineum/.ssh/gdg-cicd-key.pem
-User     : ubuntu
-
-Instance A (t3.micro  — nginx + app-server)
-  Public IP  : 3.34.32.206
-  Private IP : 10.1.0.43 (ap-northeast-2a / 10.1.0.0/24)
-
-Instance B (t3.small — app-server + redis + registry + monitoring)
-  Public IP  : 52.79.62.33
-  Private IP : 10.1.1.160 (ap-northeast-2c / 10.1.1.0/24)
-
-RDS Endpoint : ssolv-mysql.cvosykk4qy21.ap-northeast-2.rds.amazonaws.com
-```
-
-**Common SSH patterns:**
-```bash
-# Connect to Instance A / B
-ssh -i /Users/parkmineum/.ssh/gdg-cicd-key.pem -o StrictHostKeyChecking=no ubuntu@3.34.32.206
-ssh -i /Users/parkmineum/.ssh/gdg-cicd-key.pem -o StrictHostKeyChecking=no ubuntu@52.79.62.33
-
-# Restart a container (Instance B example)
-ssh -i /Users/parkmineum/.ssh/gdg-cicd-key.pem -o StrictHostKeyChecking=no ubuntu@52.79.62.33 "
-  cd ~/17th-team3-Server
-  docker compose --project-directory ~/17th-team3-Server -f deploy/docker-compose.instance-b.yml up -d --no-deps --force-recreate <service>
-"
-
-# Tail logs
-ssh -i /Users/parkmineum/.ssh/gdg-cicd-key.pem -o StrictHostKeyChecking=no ubuntu@3.34.32.206 "docker logs app-server --tail 100"
-```
-
-> If IPs have changed, run `cd deploy/terraform && terraform output` to get the latest values first.
+Claude Code는 `CLAUDE.md`와 `CLAUDE.local.md`를 모두 자동 로드하므로, 운영 작업 시 로컬 파일의 정보를 그대로 사용하세요. 팀원에 따라 SSH 키 경로가 다를 수 있으니, 팀에 합류한 새 멤버는 본인 환경에 맞춰 `CLAUDE.local.md`를 생성해야 합니다.
 
 ## Ongoing Work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ Phase 1 정책: **ktlint는 리포팅 전용 (baseline 위반 때문), 테스트
 
 ## Skills (auto-discovery)
 
-모든 skill은 `.claude/skills/<name>/SKILL.md`에 frontmatter `description`을 가지며, Claude는 현재 작업 컨텍스트와 description을 매칭하여 **자동으로** 관련 skill을 참조합니다. 아래는 수동 확인용 요약표입니다 — 작업 성격이 일치하면 해당 skill이 자동 트리거됩니다.
+모든 skill은 `.claude/skills/<name>/SKILL.md`에 frontmatter `description`을 가지며, Claude는 현재 작업 컨텍스트와 description을 매칭하여 관련 skill을 **탐색**합니다. 아래는 수동 확인용 요약표입니다 — 작업 성격이 일치하면 해당 skill이 탐색 후보에 올라옵니다.
+
+> ⚠️ **중요 — "탐색" ≠ "자동 로드"**: description 매칭으로 후보가 보인다고 해서 skill 본문이 컨텍스트에 자동 주입되지 않습니다. Claude는 git/PR/배포 같은 규칙성이 강한 작업을 **시작하기 전에 반드시 `Skill` 도구로 해당 skill 본문을 로드**해야 하며, description만 보고 규칙을 추측하지 말아야 합니다 (과잉 일반화로 프로젝트 컨벤션을 위반한 사례 있음 — PR #183 참조).
 
 | Skill | 언제 쓰이나 |
 |---|---|
@@ -80,9 +82,12 @@ See `/architecture` skill for full module dependency graph and layer rules.
 - **CI** (`.github/workflows/ci-test.yml`): triggered on PRs to `dev`; runs build + tests + Jacoco
 - **CD** (`.github/workflows/cd-deploy.yml`): triggered on push to `main`; builds Jib images → deploys to EC2 via SSH
 
-## Commit Message Language
+## Language Conventions
 
-All commit messages must be written in **English**. No Korean in commit messages.
+- **Commit messages**: 영문만 (Conventional Commits 형식, `commit-msg-check.sh` hook이 강제).
+- **PR 본문·이슈 본문**: 한국어 (`.github/PULL_REQUEST_TEMPLATE.md` 및 `.github/ISSUE_TEMPLATE/*.md` 템플릿 준수).
+- **CLAUDE.md·skill 문서 본문**: 한국어 중심, 코드·명령·프레임워크명·어노테이션은 영문 유지.
+- **코드 주석**: 원칙적으로 영문. 한국어 비즈니스 용어가 꼭 필요한 경우만 예외.
 
 ## Post-Task Follow-up Guidelines
 

--- a/thoughts/learning/resources.md
+++ b/thoughts/learning/resources.md
@@ -1,0 +1,29 @@
+# Learning Resources
+
+> `/retro` 커맨드가 세션에서 노출된 지식 공백·관심 주제를 링크 형태로 이 파일에 누적합니다.
+> 각 항목은 **"왜 이 자료가 도움되는가"** 한 줄 이유와 **추가 날짜**를 포함하세요.
+> 단순 링크 덤프는 금지 — 이유가 있어야 미래의 본인이 다시 클릭할 동기가 생깁니다.
+
+## Kotlin / Spring Boot
+
+(비어있음)
+
+## Coroutines & Async
+
+(비어있음)
+
+## Observability (OTel / Micrometer / Sentry)
+
+(비어있음)
+
+## Infrastructure & Ops (AWS / Terraform / Docker)
+
+(비어있음)
+
+## Claude Code / Compounding Engineering
+
+- [진정한 Claude Code 사용법 — Dr. Dan, babelai](https://babelai.tistory.com/42) — 컨텍스트 엔지니어링 4단계 워크플로(Research→Plan→Implement→Validate) + `thoughts/` 구조. 이 프로젝트엔 **회고 루프만 선별 도입**. 토큰 비용 이슈 및 프로젝트 규모 대비 4단계는 오버킬로 판단. (2026-04-21 시드)
+
+## ssolv-specific References
+
+(비어있음)


### PR DESCRIPTION
## Summary

Phase 2 컴파운딩 루프 완성 — 세션 종료 시 관찰을 memory / CLAUDE.md / .claude/thoughts/ / skills로 분배·축적해, 다음 세션이 축적된 컨텍스트 위에서 시작되도록 합니다.

### /retro 커맨드 신설 (`.claude/commands/retro.md`)

세션 회고 엔진. 5가지 항목(사용자·조직 사실 / 업무스타일 / 프롬프팅 습관 / 학습자료 / 스킬 갭)을 추출 → 사용자 확인 → 저장소별 분배.

### `.claude/thoughts/` 디렉터리 도입

- `thoughts/retros/` — 세션별 회고록 (git 커밋, 팀 공유)
- `thoughts/learning/resources.md` — 학습자료 누적 허브

### `CLAUDE.local.md` 분리

SSH 키 경로, 인스턴스 IP, RDS 엔드포인트 등 민감 정보를 팀 공유 `CLAUDE.md`에서 분리. `.gitignore` 처리로 개인 전용.

### 설계 결정 4가지 (`.claude/docs/compounding-engineering.md`에 기록)

- **(a)** `thoughts/`는 git 커밋 — 민감 정보는 `CLAUDE.local.md` / memory로 분기되므로 회고록엔 들어가지 않음
- **(b)** `/retro`는 수동 호출 — Claude가 세션 중 리마인드 제안만. Stop hook 자동화는 노이즈 위험으로 보류
- **(c)** 신규 skill은 `skill-creator`로 자동 생성 — `find-skills` 빈 결과일 때
- **(d)** `CLAUDE.md` 수정은 diff 제안 → 사용자 승인 → Edit — 팀 공유 파일이므로 자동 쓰기 금지

## Test plan

- [x] `./gradlew harness` 통과 (ktlint + 전체 테스트, pre-push hook)
- [x] `CLAUDE.local.md`가 `.gitignore` 처리되는지 확인 (`git check-ignore` 검증)
- [x] `/retro` 커맨드가 Claude Code auto-discovery 목록에 노출되는지 확인
- [x] CI (ktlintCheck + build + test + SonarCloud) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)