### PR TITLE
feat(ci): add sonarqube auto-fix queue workflow

### DIFF
--- a/.claude/docs/workflow/sonar-auto-fix.md
+++ b/.claude/docs/workflow/sonar-auto-fix.md
@@ -50,14 +50,14 @@ PR 1개 = `(분류 × 룰 × 모듈)` 1조합. 같은 파일을 건드리는 그
 
 ## 운영 루프
 
-```
+```text
 월요일 09:00 KST
   ↓
 sonar-issue.yml → SonarCloud API → 그룹핑 → Issue 갱신
   ↓
 담당자 체크박스 선택 → 코멘트 `/sonar-fix run`
   ↓
-sonar-fix.yml: 권한 체크 → 매트릭스 빌드 → 그룹별 작업
+sonar-fix.yml: 권한 체크 → 매트릭스 빌드 → 그룹별 직렬 처리 (max-parallel: 1)
   ├─ Claude 가 파일만 수정 → 로컬 harness 실행
   ├─ ✅ 성공: PR 생성 (🟢 auto-merge / 🟡 review-required)
   └─ ❌ 실패: Issue 에 escalate 코멘트

--- a/.claude/docs/workflow/sonar-auto-fix.md
+++ b/.claude/docs/workflow/sonar-auto-fix.md
@@ -11,7 +11,7 @@ SonarCloud 결과를 GitHub Issue 체크리스트로 큐잉하고, 승인된 그
 |---|---|
 | `.claude/sonar-allowlist.yml` | 룰별 자동화 안전성 분류 (`auto_safe` / `auto_with_review` / `manual_only`) + 공통 필터 |
 | `.claude/scripts/sonar-fetch.py` | SonarCloud API 조회 + 필터 + (rule × module) 그룹핑 + Markdown/JSON 렌더 |
-| `.github/workflows/sonar-issue.yml` | 매주 월요일 09:00 KST · GitHub Issue 갱신 |
+| `.github/workflows/sonar-issue.yml` | 매일 00:00 KST · GitHub Issue 갱신 |
 | `.github/workflows/sonar-fix.yml` | `/sonar-fix run` 코멘트 → 그룹별 PR 자동 생성 (Claude Code Action) |
 
 ## 분류 규칙
@@ -51,7 +51,7 @@ PR 1개 = `(분류 × 룰 × 모듈)` 1조합. 같은 파일을 건드리는 그
 ## 운영 루프
 
 ```text
-월요일 09:00 KST
+매일 00:00 KST
   ↓
 sonar-issue.yml → SonarCloud API → 그룹핑 → Issue 갱신
   ↓

--- a/.claude/docs/workflow/sonar-auto-fix.md
+++ b/.claude/docs/workflow/sonar-auto-fix.md
@@ -1,0 +1,77 @@
+# Sonar Auto-Fix Workflow
+
+SonarCloud 결과를 GitHub Issue 체크리스트로 큐잉하고, 승인된 그룹만 Claude 가
+자동 수정하여 PR 을 여는 두 번째 컴파운딩 루프.
+
+전체 설계 배경: `.claude/docs/workflow/harness-and-compounding-design.md` 의 후속.
+
+## 구성 요소
+
+| 파일 | 역할 |
+|---|---|
+| `.claude/sonar-allowlist.yml` | 룰별 자동화 안전성 분류 (`auto_safe` / `auto_with_review` / `manual_only`) + 공통 필터 |
+| `.claude/scripts/sonar-fetch.py` | SonarCloud API 조회 + 필터 + (rule × module) 그룹핑 + Markdown/JSON 렌더 |
+| `.github/workflows/sonar-issue.yml` | 매주 월요일 09:00 KST · GitHub Issue 갱신 |
+| `.github/workflows/sonar-fix.yml` | `/sonar-fix run` 코멘트 → 그룹별 PR 자동 생성 (Claude Code Action) |
+
+## 분류 규칙
+
+- **🟢 auto_safe**: 기계적 치환·미사용 제거 등. PR 자동 머지까지.
+- **🟡 auto_with_review**: 의미 변경 가능성 있음. PR 만 자동 생성, 사람 리뷰 후 머지.
+- **🔴 manual_only**: 도메인 맥락 필수. Issue 에 정보만 노출, 작업 안 함.
+
+추가 안전장치 (`sonar-fetch.py` 가 자동 적용):
+- effort > 30min → 제외
+- 생성 후 7일 미만 → 제외 (작성자 직접 수정 기회)
+- assignee 있으면 → 제외
+- 테스트 코드 (`/test/`, `/testFixtures/`) → 제외
+- BUG 타입은 `auto_safe` 룰이라도 강제 `auto_with_review` 로 격상
+
+## 작업 단위
+
+PR 1개 = `(분류 × 룰 × 모듈)` 1조합. 같은 파일을 건드리는 그룹은 직렬 처리.
+
+## 활성화 절차
+
+1. **로컬 테스트** (필수 secret 없이도 작동)
+   ```bash
+   curl -s "https://sonarcloud.io/api/issues/search?componentKeys=parkmineum_17th-team3-server&types=CODE_SMELL,BUG&severities=MAJOR,MINOR&statuses=OPEN&ps=500" > /tmp/sonar.json
+   python3 .claude/scripts/sonar-fetch.py --input /tmp/sonar.json --output markdown
+   ```
+
+2. **Issue 자동 생성** (`sonar-issue.yml`)
+   - `SONAR_TOKEN` repo secret 등록 (private 프로젝트만 필요)
+   - 첫 실행: `gh workflow run sonar-issue.yml`
+
+3. **PR 자동 생성** (`sonar-fix.yml`) — 기본은 dry-run
+   - `ANTHROPIC_API_KEY` secret 등록
+   - `SONAR_FIX_ACTIVE` repo variable 을 `true` 로 설정
+   - 그 전까지는 코멘트가 와도 dry-run notice 만 남기고 PR 안 만듦
+
+## 운영 루프
+
+```
+월요일 09:00 KST
+  ↓
+sonar-issue.yml → SonarCloud API → 그룹핑 → Issue 갱신
+  ↓
+담당자 체크박스 선택 → 코멘트 `/sonar-fix run`
+  ↓
+sonar-fix.yml: 권한 체크 → 매트릭스 빌드 → 그룹별 작업
+  ├─ Claude 가 파일만 수정 → 로컬 harness 실행
+  ├─ ✅ 성공: PR 생성 (🟢 auto-merge / 🟡 review-required)
+  └─ ❌ 실패: Issue 에 escalate 코멘트
+  ↓
+PR 이 ci.yml 통과 → 머지 → 다음 사이클
+```
+
+## 컴파운딩 회수
+
+같은 룰이 반복적으로 New Code 에 등장하면 → `.claude/hooks/` 차단 훅 초안 PR
+을 별도로 제안한다. (`@Value` → `value-injection-check.sh` 승격 사례의 일반화)
+
+## 알려진 한계
+
+- SonarCloud API 의 `assignee` 가 GitHub 핸들과 달라 누가 잡았는지 자동 매핑 불가 — 현재는 unassigned 만 처리.
+- `kotlin:S6518` 같은 룰은 `mutableMap` 의 `put`/`set` 의미 차이가 있어, 단순 치환이 아닌 경우 Claude 가 검출해야 함.
+- `SONAR_FIX_ACTIVE=true` 로 켠 직후 첫 실행은 매뉴얼 트리거(`workflow_dispatch`)로 해보고 안전 확인 후 코멘트 트리거에 의존할 것.

--- a/.claude/scripts/sonar-fetch.py
+++ b/.claude/scripts/sonar-fetch.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+SonarCloud auto-fix queue generator.
+
+Fetch open issues from SonarCloud, filter via allowlist, group by (rule × module),
+and emit either JSON (for downstream automation) or markdown (for GitHub Issue body).
+
+Usage:
+    python3 .claude/scripts/sonar-fetch.py --output markdown
+    python3 .claude/scripts/sonar-fetch.py --output json
+
+Env:
+    SONAR_TOKEN      Optional. Required for private projects.
+    SONAR_PROJECT    Optional override. Defaults to value in build.gradle.kts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = REPO_ROOT / ".claude" / "sonar-allowlist.yml"
+
+DEFAULT_PROJECT = "parkmineum_17th-team3-server"
+SONAR_HOST = "https://sonarcloud.io"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Allowlist loader (minimal YAML — avoids PyYAML dependency)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Allowlist:
+    auto_safe: dict[str, str] = field(default_factory=dict)
+    auto_with_review: dict[str, str] = field(default_factory=dict)
+    manual_only: dict[str, str] = field(default_factory=dict)
+    max_effort_minutes: int = 30
+    min_age_days: int = 7
+    exclude_paths: list[str] = field(default_factory=list)
+
+    def classify(self, rule: str) -> str | None:
+        if rule in self.auto_safe:
+            return "auto_safe"
+        if rule in self.auto_with_review:
+            return "auto_with_review"
+        if rule in self.manual_only:
+            return "manual_only"
+        return None
+
+    def reason(self, rule: str) -> str:
+        return (
+            self.auto_safe.get(rule)
+            or self.auto_with_review.get(rule)
+            or self.manual_only.get(rule)
+            or ""
+        )
+
+
+def load_allowlist(path: Path) -> Allowlist:
+    """Parse the small subset of YAML used by sonar-allowlist.yml.
+
+    Format:
+        section_name:
+          - rule: kotlin:S1234
+            reason: "..."
+        filters:
+          max_effort_minutes: 30
+    """
+    a = Allowlist()
+    section: str | None = None
+    in_filters = False
+    pending_rule: str | None = None
+    def strip_inline_comment(s: str) -> str:
+        # Strip ` # comment` (preserves `#` inside quoted strings — naive but YAML stays simple here).
+        in_quote: str | None = None
+        for i, ch in enumerate(s):
+            if ch in ('"', "'"):
+                in_quote = None if in_quote == ch else (in_quote or ch)
+            elif ch == "#" and in_quote is None and (i == 0 or s[i - 1] in " \t"):
+                return s[:i].rstrip()
+        return s.rstrip()
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = strip_inline_comment(raw.rstrip())
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        # Top-level section
+        if not line.startswith(" "):
+            key = line.split(":", 1)[0].strip()
+            if key in {"auto_safe", "auto_with_review", "manual_only"}:
+                section, in_filters = key, False
+            elif key == "filters":
+                section, in_filters = None, True
+            else:
+                section, in_filters = None, False
+            pending_rule = None
+            continue
+        stripped = line.strip()
+        if in_filters:
+            if ":" in stripped:
+                k, v = (s.strip() for s in stripped.split(":", 1))
+                v = v.strip().strip('"').strip("'")
+                if k == "max_effort_minutes":
+                    a.max_effort_minutes = int(v)
+                elif k == "min_age_days":
+                    a.min_age_days = int(v)
+                elif k.startswith("- "):
+                    a.exclude_paths.append(k[2:].strip().strip('"'))
+            elif stripped.startswith("- "):
+                a.exclude_paths.append(stripped[2:].strip().strip('"'))
+            continue
+        if section is None:
+            continue
+        m = re.match(r"-\s*rule:\s*(.+)", stripped)
+        if m:
+            pending_rule = m.group(1).strip().strip('"').strip("'")
+            getattr(a, section)[pending_rule] = ""
+            continue
+        m = re.match(r"reason:\s*(.+)", stripped)
+        if m and pending_rule is not None:
+            reason = m.group(1).strip().strip('"').strip("'")
+            getattr(a, section)[pending_rule] = reason
+    return a
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SonarCloud API
+# ──────────────────────────────────────────────────────────────────────
+
+
+def fetch_issues(project: str, token: str | None) -> list[dict[str, Any]]:
+    """Fetch all open CODE_SMELL / BUG issues at MAJOR/MINOR severity."""
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        params = {
+            "componentKeys": project,
+            "types": "CODE_SMELL,BUG",
+            "severities": "MAJOR,MINOR",
+            "statuses": "OPEN",
+            "resolved": "false",
+            "ps": "500",
+            "p": str(page),
+        }
+        url = f"{SONAR_HOST}/api/issues/search?{urllib.parse.urlencode(params)}"
+        req = urllib.request.Request(url)
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        batch = data.get("issues", [])
+        issues.extend(batch)
+        total = data.get("total", 0)
+        if len(issues) >= total or not batch:
+            break
+        page += 1
+        if page > 20:  # safety
+            break
+    return issues
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Filtering & grouping
+# ──────────────────────────────────────────────────────────────────────
+
+
+_EFFORT_RE = re.compile(r"(\d+)(min|h|d)")
+
+
+def effort_minutes(effort: str | None) -> int:
+    if not effort:
+        return 0
+    m = _EFFORT_RE.match(effort)
+    if not m:
+        return 9999
+    n, unit = int(m.group(1)), m.group(2)
+    return n if unit == "min" else n * 60 if unit == "h" else n * 480
+
+
+def parse_module(component: str) -> str:
+    """parkmineum_...:ssolv-api-core/src/main/... → ssolv-api-core"""
+    m = re.search(r":(ssolv-[^/]+)/", component)
+    return m.group(1) if m else "unknown"
+
+
+def parse_path(component: str) -> str:
+    """parkmineum_...:ssolv-x/src/main/foo.kt → ssolv-x/src/main/foo.kt"""
+    return component.split(":", 1)[1] if ":" in component else component
+
+
+def days_since(iso_ts: str) -> int:
+    if not iso_ts:
+        return 0
+    s = iso_ts.replace("Z", "+00:00")
+    # SonarCloud emits `+0000` (no colon); fromisoformat needs `+00:00` on <3.11.
+    if re.search(r"[+-]\d{4}$", s):
+        s = s[:-2] + ":" + s[-2:]
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return 0
+    return (datetime.now(timezone.utc) - dt).days
+
+
+def issue_classification(issue: dict[str, Any], allow: Allowlist) -> str | None:
+    """Return classification or None if filtered out."""
+    rule = issue.get("rule", "")
+    cls = allow.classify(rule)
+    if cls is None:
+        return None
+    if effort_minutes(issue.get("effort", "")) > allow.max_effort_minutes:
+        return None
+    if days_since(issue.get("creationDate", "")) < allow.min_age_days:
+        return None
+    if issue.get("assignee"):
+        return None
+    path = parse_path(issue.get("component", ""))
+    if "/test/" in path or "/testFixtures/" in path:
+        return None
+    # BUG type — even on auto_safe rules, force review
+    if issue.get("type") == "BUG" and cls == "auto_safe":
+        return "auto_with_review"
+    return cls
+
+
+def group_issues(
+    issues: list[dict[str, Any]], allow: Allowlist
+) -> tuple[dict[tuple[str, str, str], list[dict[str, Any]]], list[dict[str, Any]]]:
+    """Group filtered issues by (classification, rule, module).
+
+    Returns (groups, excluded) where excluded contains issues that were filtered out
+    but matched a manual_only rule or were otherwise informational.
+    """
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    excluded: list[dict[str, Any]] = []
+    for issue in issues:
+        cls = issue_classification(issue, allow)
+        rule = issue.get("rule", "")
+        # manual_only is informational — never group, always excluded
+        if cls == "manual_only":
+            excluded.append(issue)
+            continue
+        if cls is None:
+            if allow.classify(rule) == "manual_only":
+                excluded.append(issue)
+            continue
+        module = parse_module(issue.get("component", ""))
+        groups[(cls, rule, module)].append(issue)
+    return groups, excluded
+
+
+def detect_file_conflicts(
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]],
+) -> list[tuple[str, str, str]]:
+    """Find groups that touch the same file → must be serialized."""
+    file_to_groups: dict[str, set[tuple[str, str, str]]] = defaultdict(set)
+    for key, issues in groups.items():
+        for issue in issues:
+            file_to_groups[parse_path(issue.get("component", ""))].add(key)
+    conflicts: set[tuple[tuple[str, str, str], tuple[str, str, str]]] = set()
+    for keys in file_to_groups.values():
+        if len(keys) <= 1:
+            continue
+        ordered = sorted(keys)
+        for i in range(len(ordered)):
+            for j in range(i + 1, len(ordered)):
+                conflicts.add((ordered[i], ordered[j]))
+    # Flatten for serialization
+    return [(f"{a[0]}/{a[1]}/{a[2]}", f"{b[0]}/{b[1]}/{b[2]}", "shared file") for a, b in conflicts]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Output renderers
+# ──────────────────────────────────────────────────────────────────────
+
+
+CLASS_BADGE = {
+    "auto_safe": "🟢",
+    "auto_with_review": "🟡",
+    "manual_only": "🔴",
+}
+
+
+def render_json(
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]],
+    excluded: list[dict[str, Any]],
+    allow: Allowlist,
+) -> str:
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "groups": [
+            {
+                "id": f"{cls}-{rule.replace(':', '_')}-{module}",
+                "classification": cls,
+                "rule": rule,
+                "module": module,
+                "count": len(items),
+                "reason": allow.reason(rule),
+                "files": sorted({parse_path(i.get("component", "")) for i in items}),
+                "issue_keys": [i.get("key") for i in items],
+            }
+            for (cls, rule, module), items in sorted(groups.items())
+        ],
+        "manual_only": [
+            {
+                "rule": i.get("rule"),
+                "file": parse_path(i.get("component", "")),
+                "line": i.get("line"),
+                "message": i.get("message", ""),
+                "reason": allow.reason(i.get("rule", "")),
+            }
+            for i in excluded
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def render_markdown(
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]],
+    excluded: list[dict[str, Any]],
+    conflicts: list[tuple[str, str, str]],
+    allow: Allowlist,
+    project: str,
+) -> str:
+    by_class: dict[str, list[tuple[tuple[str, str, str], list[dict[str, Any]]]]] = defaultdict(list)
+    for key, items in groups.items():
+        by_class[key[0]].append((key, items))
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total_count = sum(len(v) for v in groups.values()) + len(excluded)
+    safe_count = sum(len(v) for k, v in groups.items() if k[0] == "auto_safe")
+    review_count = sum(len(v) for k, v in groups.items() if k[0] == "auto_with_review")
+    manual_count = len(excluded)
+
+    out: list[str] = []
+    out.append(f"# 🔍 Sonar Auto-Fix Queue — {today}")
+    out.append("")
+    out.append(f"> 자동 생성됨 by `.github/workflows/sonar-issue.yml`")
+    out.append(f"> 데이터: SonarCloud `{project}` · OPEN · CODE_SMELL/BUG · MAJOR/MINOR")
+    out.append(
+        f"> 총 **{total_count}건** → 🟢 Auto-safe {safe_count} / "
+        f"🟡 Auto-with-review {review_count} / 🔴 Manual {manual_count}"
+    )
+    out.append("")
+    out.append("## 사용법")
+    out.append("- 체크박스 선택 후 댓글에 `/sonar-fix run` → 선택된 그룹 동시 처리")
+    out.append("- 🟢 = PR 자동 머지 / 🟡 = PR 만 생성 (사람 리뷰 필수) / 🔴 = 작업 안 함")
+    out.append("- 같은 파일을 건드리는 그룹은 직렬 처리")
+    out.append("- 그룹별 최대 2회 재시도, 실패 시 이 Issue 에 escalate 코멘트")
+    out.append("")
+
+    if not by_class:
+        out.append("## 처리할 그룹 없음")
+        out.append("")
+        out.append(
+            "현재 allowlist 와 필터 조건을 만족하는 OPEN 이슈가 없습니다. "
+            "(`.claude/sonar-allowlist.yml` 참고)"
+        )
+        out.append("")
+
+    for cls in ("auto_safe", "auto_with_review"):
+        items_for_class = by_class.get(cls, [])
+        if not items_for_class:
+            continue
+        badge = CLASS_BADGE[cls]
+        title = "Auto-safe" if cls == "auto_safe" else "Auto-with-review (자동 머지 X)"
+        out.append(f"## {badge} {title}")
+        out.append("")
+        for idx, ((_cls, rule, module), issues) in enumerate(
+            sorted(items_for_class, key=lambda x: -len(x[1])), start=1
+        ):
+            group_id = f"{cls}-{rule.replace(':', '_')}-{module}"
+            sample = issues[0]
+            out.append(
+                f"### `[ ]` `{group_id}` · `{rule}` × `{module}` ({len(issues)}건)"
+            )
+            out.append("")
+            out.append(f"**메시지**: {sample.get('message','')[:120]}")
+            out.append(f"**근거**: {allow.reason(rule)}")
+            effort_total = sum(effort_minutes(i.get("effort", "")) for i in issues)
+            out.append(f"**Effort**: ~{effort_total}min (예상)")
+            out.append("")
+            out.append("<details><summary>대상 파일</summary>")
+            out.append("")
+            out.append("| 파일 | 라인 |")
+            out.append("|---|---:|")
+            for i in issues[:20]:
+                path = parse_path(i.get("component", ""))
+                out.append(f"| `{path}` | {i.get('line', '-')} |")
+            if len(issues) > 20:
+                out.append(f"| ...{len(issues)-20}건 더 | |")
+            out.append("")
+            out.append("</details>")
+            out.append("")
+
+    if excluded:
+        out.append("## 🔴 Manual only (작업 안 함, 참고용)")
+        out.append("")
+        out.append("| 룰 | 파일 | 라인 | 사유 |")
+        out.append("|---|---|---:|---|")
+        for i in excluded[:30]:
+            out.append(
+                f"| `{i.get('rule')}` | `{parse_path(i.get('component', ''))}` "
+                f"| {i.get('line', '-')} | {allow.reason(i.get('rule', ''))} |"
+            )
+        if len(excluded) > 30:
+            out.append(f"| ...{len(excluded)-30}건 더 | | | |")
+        out.append("")
+
+    if conflicts:
+        out.append("## ⚠️ 직렬화 필요 (같은 파일 건드림)")
+        out.append("")
+        for a, b, _ in conflicts[:20]:
+            out.append(f"- `{a}` ↔ `{b}`")
+        out.append("")
+
+    out.append("---")
+    out.append("")
+    out.append(
+        f"🤖 Allowlist: `.claude/sonar-allowlist.yml` · "
+        f"규칙 추가/제거는 PR 머지 이력 기반"
+    )
+    return "\n".join(out)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--output", choices=["json", "markdown"], default="markdown")
+    p.add_argument("--project", default=os.environ.get("SONAR_PROJECT", DEFAULT_PROJECT))
+    p.add_argument("--allowlist", default=str(ALLOWLIST_PATH))
+    p.add_argument("--input", help="Local JSON file for testing (skips API call)")
+    args = p.parse_args()
+
+    allow = load_allowlist(Path(args.allowlist))
+
+    if args.input:
+        with open(args.input, encoding="utf-8") as f:
+            issues = json.load(f).get("issues", [])
+    else:
+        token = os.environ.get("SONAR_TOKEN")
+        try:
+            issues = fetch_issues(args.project, token)
+        except Exception as exc:  # noqa: BLE001 — surface to CI logs
+            print(f"::error::SonarCloud fetch failed: {exc}", file=sys.stderr)
+            return 1
+
+    groups, excluded = group_issues(issues, allow)
+    conflicts = detect_file_conflicts(groups)
+
+    if args.output == "json":
+        print(render_json(groups, excluded, allow))
+    else:
+        print(render_markdown(groups, excluded, conflicts, allow, args.project))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/sonar-fetch.py
+++ b/.claude/scripts/sonar-fetch.py
@@ -49,6 +49,9 @@ class Allowlist:
     max_effort_minutes: int = 30
     min_age_days: int = 7
     exclude_paths: list[str] = field(default_factory=list)
+    # required_assignee = None → 미배정 이슈만 처리 (현재 정책)
+    # 문자열 값 → 해당 사용자에게 배정된 이슈만 처리
+    required_assignee: str | None = None
 
     def classify(self, rule: str) -> str | None:
         if rule in self.auto_safe:
@@ -116,6 +119,8 @@ def load_allowlist(path: Path) -> Allowlist:
                     a.max_effort_minutes = int(v)
                 elif k == "min_age_days":
                     a.min_age_days = int(v)
+                elif k == "required_assignee":
+                    a.required_assignee = None if v in ("null", "~", "") else v
                 elif k.startswith("- "):
                     a.exclude_paths.append(k[2:].strip().strip('"'))
             elif stripped.startswith("- "):
@@ -214,51 +219,85 @@ def days_since(iso_ts: str) -> int:
     return (datetime.now(timezone.utc) - dt).days
 
 
-def issue_classification(issue: dict[str, Any], allow: Allowlist) -> str | None:
-    """Return classification or None if filtered out."""
+def _path_excluded(path: str, patterns: list[str]) -> bool:
+    """Glob-aware substring match. `**/X/**` 는 `/X/` 부분문자열로 단순화한다."""
+    for pattern in patterns:
+        # `**/segment/**` → `/segment/` 부분 매칭
+        core = pattern.strip("*/")
+        if not core:
+            continue
+        needle = f"/{core}/"
+        if needle in path or path.startswith(f"{core}/"):
+            return True
+    return False
+
+
+def issue_classification(
+    issue: dict[str, Any], allow: Allowlist
+) -> tuple[str | None, str | None]:
+    """Return (classification, gate_reason).
+
+    classification: 최종 분류 (`auto_safe` / `auto_with_review` / `manual_only`)
+                    또는 룰이 allowlist 에 없으면 None.
+    gate_reason:    분류는 매칭됐으나 게이팅으로 제외됐을 때의 사유 ("effort" /
+                    "age" / "assignee" / "path"). 매칭 실패면 None.
+    """
     rule = issue.get("rule", "")
     cls = allow.classify(rule)
     if cls is None:
-        return None
+        return None, None
+    if cls == "manual_only":
+        return cls, None
+    # 게이팅 — auto_safe / auto_with_review 만 적용
     if effort_minutes(issue.get("effort", "")) > allow.max_effort_minutes:
-        return None
+        return None, "effort"
     if days_since(issue.get("creationDate", "")) < allow.min_age_days:
-        return None
-    if issue.get("assignee"):
-        return None
+        return None, "age"
+    assignee = issue.get("assignee")
+    if allow.required_assignee is None:
+        if assignee:
+            return None, "assignee"
+    elif assignee != allow.required_assignee:
+        return None, "assignee"
     path = parse_path(issue.get("component", ""))
-    if "/test/" in path or "/testFixtures/" in path:
-        return None
+    if _path_excluded(path, allow.exclude_paths):
+        return None, "path"
     # BUG type — even on auto_safe rules, force review
     if issue.get("type") == "BUG" and cls == "auto_safe":
-        return "auto_with_review"
-    return cls
+        return "auto_with_review", None
+    return cls, None
 
 
 def group_issues(
     issues: list[dict[str, Any]], allow: Allowlist
-) -> tuple[dict[tuple[str, str, str], list[dict[str, Any]]], list[dict[str, Any]]]:
+) -> tuple[
+    dict[tuple[str, str, str], list[dict[str, Any]]],
+    list[dict[str, Any]],
+    list[tuple[dict[str, Any], str]],
+]:
     """Group filtered issues by (classification, rule, module).
 
-    Returns (groups, excluded) where excluded contains issues that were filtered out
-    but matched a manual_only rule or were otherwise informational.
+    Returns (groups, excluded, silently_filtered):
+      - groups:            처리 대상 그룹
+      - excluded:          manual_only — 정보 노출용
+      - silently_filtered: allowlist 에는 있으나 게이팅(effort/age/assignee/path)으로
+                           제외된 이슈와 그 사유. total_count 정확도를 위해 추적.
     """
     groups: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
     excluded: list[dict[str, Any]] = []
+    silently_filtered: list[tuple[dict[str, Any], str]] = []
     for issue in issues:
-        cls = issue_classification(issue, allow)
-        rule = issue.get("rule", "")
-        # manual_only is informational — never group, always excluded
+        cls, gate = issue_classification(issue, allow)
         if cls == "manual_only":
             excluded.append(issue)
             continue
         if cls is None:
-            if allow.classify(rule) == "manual_only":
-                excluded.append(issue)
+            if gate is not None:
+                silently_filtered.append((issue, gate))
             continue
         module = parse_module(issue.get("component", ""))
-        groups[(cls, rule, module)].append(issue)
-    return groups, excluded
+        groups[(cls, issue.get("rule", ""), module)].append(issue)
+    return groups, excluded, silently_filtered
 
 
 def detect_file_conflicts(
@@ -296,8 +335,12 @@ CLASS_BADGE = {
 def render_json(
     groups: dict[tuple[str, str, str], list[dict[str, Any]]],
     excluded: list[dict[str, Any]],
+    silently_filtered: list[tuple[dict[str, Any], str]],
     allow: Allowlist,
 ) -> str:
+    silent_counts: dict[str, int] = defaultdict(int)
+    for _, gate in silently_filtered:
+        silent_counts[gate] += 1
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "groups": [
@@ -323,6 +366,7 @@ def render_json(
             }
             for i in excluded
         ],
+        "silently_filtered": dict(silent_counts),
     }
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
@@ -330,6 +374,7 @@ def render_json(
 def render_markdown(
     groups: dict[tuple[str, str, str], list[dict[str, Any]]],
     excluded: list[dict[str, Any]],
+    silently_filtered: list[tuple[dict[str, Any], str]],
     conflicts: list[tuple[str, str, str]],
     allow: Allowlist,
     project: str,
@@ -338,8 +383,14 @@ def render_markdown(
     for key, items in groups.items():
         by_class[key[0]].append((key, items))
 
+    silent_counts: dict[str, int] = defaultdict(int)
+    for _, gate in silently_filtered:
+        silent_counts[gate] += 1
+    silent_total = sum(silent_counts.values())
+
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    total_count = sum(len(v) for v in groups.values()) + len(excluded)
+    actionable_total = sum(len(v) for v in groups.values()) + len(excluded)
+    total_count = actionable_total + silent_total
     safe_count = sum(len(v) for k, v in groups.items() if k[0] == "auto_safe")
     review_count = sum(len(v) for k, v in groups.items() if k[0] == "auto_with_review")
     manual_count = len(excluded)
@@ -352,13 +403,16 @@ def render_markdown(
     out.append(
         f"> 총 **{total_count}건** → 🟢 Auto-safe {safe_count} / "
         f"🟡 Auto-with-review {review_count} / 🔴 Manual {manual_count}"
+        + (f" / ⚪ Filtered {silent_total}" if silent_total else "")
     )
+    if silent_total:
+        breakdown = ", ".join(f"{k}={v}" for k, v in sorted(silent_counts.items()))
+        out.append(f"> Filtered breakdown: {breakdown}")
     out.append("")
     out.append("## 사용법")
-    out.append("- 체크박스 선택 후 댓글에 `/sonar-fix run` → 선택된 그룹 동시 처리")
+    out.append("- 체크박스 선택 후 댓글에 `/sonar-fix run` → 선택된 그룹 직렬 처리")
     out.append("- 🟢 = PR 자동 머지 / 🟡 = PR 만 생성 (사람 리뷰 필수) / 🔴 = 작업 안 함")
-    out.append("- 같은 파일을 건드리는 그룹은 직렬 처리")
-    out.append("- 그룹별 최대 2회 재시도, 실패 시 이 Issue 에 escalate 코멘트")
+    out.append("- 실패 시 이 Issue 에 escalate 코멘트")
     out.append("")
 
     if not by_class:
@@ -461,13 +515,17 @@ def main() -> int:
             print(f"::error::SonarCloud fetch failed: {exc}", file=sys.stderr)
             return 1
 
-    groups, excluded = group_issues(issues, allow)
+    groups, excluded, silently_filtered = group_issues(issues, allow)
     conflicts = detect_file_conflicts(groups)
 
     if args.output == "json":
-        print(render_json(groups, excluded, allow))
+        print(render_json(groups, excluded, silently_filtered, allow))
     else:
-        print(render_markdown(groups, excluded, conflicts, allow, args.project))
+        print(
+            render_markdown(
+                groups, excluded, silently_filtered, conflicts, allow, args.project
+            )
+        )
     return 0
 
 

--- a/.claude/skills/git-conventions/SKILL.md
+++ b/.claude/skills/git-conventions/SKILL.md
@@ -49,6 +49,19 @@ feat: migrate external clients from WebClient to Ktor Client
 - 메시지는 영문 소문자로 시작, 마침표 없음
 - 제목은 72자 이내
 
+## 작업 시작 순서 (중요)
+
+PR 작성 전에 **반드시 이슈를 먼저 만든다** — 브랜치 네이밍이 이슈 번호를 요구하기 때문.
+
+```
+1. gh issue create  → 이슈 번호 확보 (예: #187)
+2. git checkout -b feat/#187  → 이슈 번호로 브랜치
+3. 작업 → commit → push
+4. gh pr create  → PR 본문에 "Close #187" 또는 "Resolves #187"
+```
+
+이슈 없이 작업이 시작된 경우(예: 핫픽스): 작업 도중에라도 이슈를 만들고 브랜치명을 맞춘다. 이미 push 한 PR 이라도 다음 PR 부터는 이 순서를 지킨다.
+
 ## 브랜치 네이밍
 
 ```
@@ -60,18 +73,29 @@ feat: migrate external clients from WebClient to Ktor Client
 - `fix/#456`
 - `refactor/#169`
 
+❌ 안티 패턴: `feat/sonar-auto-fix-workflow` (이슈 번호 없이 설명형 슬러그) — PR #186 회고 참조
+
 ## PR 작성
 
 `.github/PULL_REQUEST_TEMPLATE.md` 양식은 **무시하고** 아래 형식을 사용한다. 가치 중심 서술이 핵심 — "무엇을 바꿨는가"보다 "왜 이 변경이 필요했는가"를 먼저 전달한다.
 
+### 언어 규칙
+
+- **PR 제목**: 영문 (Conventional Commits 와 동일 규약 — `type(scope): message`, 소문자 시작, 72자 이내)
+- **PR 본문**: **한국어로 작성** (헤딩은 영문 `## Summary` / `## Test plan` 유지, 본문 내용은 한국어)
+- **커밋 메시지**: 영문 (commit-msg-check.sh 훅이 강제)
+- **이슈 본문**: 한국어
+
+### 본문 형식
+
 ```markdown
 ## Summary
 
-<변경의 맥락과 목적을 1~2문장으로>
+<변경의 맥락과 목적을 1~2문장의 한국어로>
 
 ### <변경 묶음 1 제목> (커밋이 여러 개거나 주제가 나뉠 때만 ### 사용)
 
-- 핵심 변경 사항과 이유
+- 핵심 변경 사항과 이유 (한국어)
 - 설계 결정이 있으면 why를 포함
 
 ### <변경 묶음 2 제목>
@@ -94,6 +118,7 @@ feat: migrate external clients from WebClient to Ktor Client
 - 커밋이 여러 개이거나 주제가 나뉠 때만 `###` 서브섹션 사용
 - 설계 결정이 있으면 **(a) / (b) / ...** 형식으로 명시 (왜 다른 방법이 아닌지 포함)
 - Test plan은 실제로 검증한 것만 — 형식적 체크리스트 금지
+- 헤딩은 영문 그대로(`## Summary`, `## Test plan`), 본문 텍스트만 한국어
 
 **PR 머지 대상**: `dev` 브랜치 (CI는 `dev` 브랜치 PR에서 트리거됨)
 

--- a/.claude/sonar-allowlist.yml
+++ b/.claude/sonar-allowlist.yml
@@ -54,11 +54,11 @@ manual_only:
   - rule: kotlin:S138
     reason: "Function too long — 분리 결정은 사람 판단"
 
-# 공통 필터 (auto_safe / auto_with_review 양쪽에 적용)
+# 공통 필터 (auto_safe / auto_with_review 양쪽에 적용 — manual_only 는 정보 노출용이라 미적용)
 filters:
   max_effort_minutes: 30
   min_age_days: 7              # 갓 만든 이슈는 작성자가 직접 고치도록 유예
-  exclude_paths:
+  exclude_paths:               # `**/X/**` 는 `/X/` 부분 매칭으로 단순화됨
     - "**/test/**"
     - "**/testFixtures/**"
-  required_assignee: null      # null = unassigned 만 대상
+  required_assignee: null      # null = unassigned 만 대상, 문자열 = 해당 사용자 배정만

--- a/.claude/sonar-allowlist.yml
+++ b/.claude/sonar-allowlist.yml
@@ -1,0 +1,64 @@
+# SonarCloud auto-fix allowlist
+#
+# 이 파일은 sonar-fetch.py 가 읽어서 자동화 범위를 결정한다.
+# 룰을 추가/제거할 때는 반드시 PR 머지 이력(회귀 발생 여부)을 근거로 한다.
+#
+# 분류 기준:
+#   auto_safe        — Claude 가 수정 후 자동 머지까지 진행
+#   auto_with_review — Claude 가 PR 만 생성, 사람 리뷰 후 머지
+#   manual_only      — 자동화 제외, GitHub Issue 에 알림만 노출
+#
+# 처음 등록 기준은 실제 SonarCloud 결과(2026-04-25 30건)를 보고 안전성 평가한 결과다.
+
+auto_safe:
+  - rule: kotlin:S6518
+    reason: "Replace function call with indexed accessor — `.get(k)` → `[k]` 순수 문법 치환"
+  - rule: kotlin:S1144
+    reason: "Remove unused private method — 호출자 grep 으로 안전 확인 가능"
+  - rule: kotlin:S1172
+    reason: "Use `_` for unused lambda parameter — 의미 보존"
+  - rule: kotlin:S1125
+    reason: "Remove unnecessary boolean literal — `if (x) true else false` → `x`"
+  - rule: kotlin:S1481
+    reason: "Remove unused local variable"
+  - rule: kotlin:S125
+    reason: "Remove commented-out code"
+  - rule: kotlin:S6605
+    reason: "Use isEmpty/isNotEmpty — 의미 보존"
+  - rule: kotlin:S1155
+    reason: "Use isNotEmpty instead of size > 0"
+  - rule: kotlin:S1128
+    reason: "Remove unused imports"
+  - rule: kotlin:S6611
+    reason: "Use indexed access on map — 안전한 문법 치환"
+
+auto_with_review:
+  - rule: kotlin:S6524
+    reason: "Make collection immutable — 호출자가 add() 호출 시 깨질 위험"
+  - rule: kotlin:S6619
+    reason: "Remove useless non-null check — 흐름 분석 변경 시 깨질 수 있음"
+  - rule: kotlin:S6532
+    reason: "Replace if/throw with require/error — 예외 타입 변경됨"
+  - rule: kotlin:S6517
+    reason: "Functional interface 변환 — public API 시그니처 영향"
+
+manual_only:
+  - rule: kotlin:S6311
+    reason: "Dispatcher 결정은 비동기 설계 영향, 도메인 맥락 필요"
+  - rule: kotlin:S6310
+    reason: "Hardcoded dispatcher — 동일"
+  - rule: kotlin:S1874
+    reason: "Deprecated API 사용 — 대체 API 결정은 도메인 결정"
+  - rule: kotlin:S3776
+    reason: "Cognitive complexity — 리팩토링은 도메인 맥락 필요"
+  - rule: kotlin:S138
+    reason: "Function too long — 분리 결정은 사람 판단"
+
+# 공통 필터 (auto_safe / auto_with_review 양쪽에 적용)
+filters:
+  max_effort_minutes: 30
+  min_age_days: 7              # 갓 만든 이슈는 작성자가 직접 고치도록 유예
+  exclude_paths:
+    - "**/test/**"
+    - "**/testFixtures/**"
+  required_assignee: null      # null = unassigned 만 대상

--- a/.github/workflows/sonar-fix.yml
+++ b/.github/workflows/sonar-fix.yml
@@ -1,0 +1,264 @@
+name: Sonar Auto-Fix Dispatch
+
+# Sonar Auto-Fix Queue 이슈에서 `/sonar-fix run` 코멘트가 달리면, 체크된 그룹을 파싱해
+# 그룹별로 브랜치를 만들고 Claude 가 수정한 PR 을 자동 생성한다.
+#
+# 활성화 조건 (모두 만족 필요):
+#   1. ANTHROPIC_API_KEY secret 설정
+#   2. Sonar Auto-Fix Queue 이슈가 sonar-issue.yml 로 생성되어 있어야 함
+#   3. 코멘트 작성자가 repo 의 write 권한 보유
+#
+# 안전장치:
+#   - 그룹별 worktree 분리, 동일 파일 충돌 시 직렬화 (parse 단계에서 감지)
+#   - 그룹별 최대 2회 재시도, 실패 시 이슈에 escalate 코멘트
+#   - 🟡 그룹은 PR 만 생성, auto-merge 라벨 안 붙임
+#   - BUG 또는 VULNERABILITY 가 섞이면 자동 머지 차단
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      group_ids:
+        description: 'Comma-separated group IDs (e.g. auto_safe-kotlin_S6518-ssolv-api-common)'
+        required: true
+      issue_number:
+        description: 'Source issue number for status reporting'
+        required: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+env:
+  ISSUE_LABEL: sonar-auto-fix-queue
+  TRIGGER_PHRASE: '/sonar-fix run'
+
+jobs:
+  # ── Job 1: Parse approval & extract group IDs ─────────────────────
+  parse:
+    name: Parse approval
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request == null &&
+       contains(github.event.comment.body, '/sonar-fix run'))
+    outputs:
+      group_ids: ${{ steps.extract.outputs.group_ids }}
+      issue_number: ${{ steps.extract.outputs.issue_number }}
+      authorized: ${{ steps.authz.outputs.authorized }}
+
+    steps:
+      - name: Authorize commenter
+        id: authz
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          # write 권한 이상만 허용
+          permission=$(gh api "/repos/$REPO/collaborators/$ACTOR/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          if [[ "$permission" == "admin" || "$permission" == "write" || "$permission" == "maintain" ]]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::User $ACTOR (permission=$permission) is not authorized."
+          fi
+
+      - name: Authorize dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "authorized=true" >> "$GITHUB_OUTPUT"
+        id: authz_dispatch
+
+      - name: Checkout (for issue body parsing)
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@v4
+
+      - name: Extract checked group IDs
+        id: extract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          DISPATCH_IDS: ${{ github.event.inputs.group_ids }}
+          DISPATCH_ISSUE: ${{ github.event.inputs.issue_number }}
+        run: |
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            echo "group_ids=$DISPATCH_IDS" >> "$GITHUB_OUTPUT"
+            echo "issue_number=$DISPATCH_ISSUE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          body=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
+          # `[x]` 또는 `[X]` 가 체크된 라인에서 group ID (백틱으로 감싼 첫 토큰) 추출
+          ids=$(echo "$body" | grep -E '^### `\[[xX]\]`' \
+            | grep -oE '`[a-z_]+-[a-zA-Z0-9_]+-ssolv-[a-z-]+`' \
+            | tr -d '`' \
+            | sort -u \
+            | tr '\n' ',' | sed 's/,$//')
+          echo "Detected group IDs: $ids"
+          echo "group_ids=$ids" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+  # ── Job 2: Build fix matrix ───────────────────────────────────────
+  build-matrix:
+    name: Build fix matrix
+    needs: parse
+    if: needs.parse.outputs.authorized == 'true' && needs.parse.outputs.group_ids != ''
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build matrix
+        id: build
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GROUP_IDS: ${{ needs.parse.outputs.group_ids }}
+        run: |
+          python3 .claude/scripts/sonar-fetch.py --output json > sonar.json
+          # 선택된 group_ids 만 남기고 file conflict 가 있으면 직렬화 마킹
+          python3 - "$GROUP_IDS" <<'PY' >> "$GITHUB_OUTPUT"
+          import json, sys, os
+          ids = set(s.strip() for s in sys.argv[1].split(',') if s.strip())
+          with open('sonar.json') as f: data = json.load(f)
+          selected = [g for g in data['groups'] if g['id'] in ids]
+          # conflict detection: 같은 파일 등장 그룹 → conflict_with 채움
+          file_owners = {}
+          for g in selected:
+              for f in g['files']:
+                  file_owners.setdefault(f, []).append(g['id'])
+          for g in selected:
+              conflicts = set()
+              for f in g['files']:
+                  for other in file_owners[f]:
+                      if other != g['id']:
+                          conflicts.add(other)
+              g['conflicts_with'] = sorted(conflicts)
+          matrix = {'include': selected}
+          print(f"matrix={json.dumps(matrix)}")
+          PY
+
+  # ── Job 3: Fix each group ─────────────────────────────────────────
+  fix:
+    name: Fix ${{ matrix.id }}
+    needs: [parse, build-matrix]
+    if: needs.build-matrix.outputs.matrix != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Create branch
+        env:
+          GROUP_ID: ${{ matrix.id }}
+        run: |
+          branch="auto/sonar-fix/${GROUP_ID}"
+          # Sanitize: replace anything but [a-zA-Z0-9/_-]
+          branch=$(echo "$branch" | tr -c 'a-zA-Z0-9/_-' '-')
+          echo "BRANCH=$branch" >> "$GITHUB_ENV"
+          git checkout -b "$branch"
+
+      # ─────────────────────────────────────────────────────────────
+      # 활성화 모드: ANTHROPIC_API_KEY 가 secrets 에 있으면 Claude Code Action 으로 수정.
+      # 비활성화 모드 (기본): stub 만 실행, PR 생성 안 함. 안전한 dry-run.
+      #
+      # 활성화 절차:
+      #   1. ANTHROPIC_API_KEY secret 등록
+      #   2. repo variable SONAR_FIX_ACTIVE = 'true' 설정
+      # ─────────────────────────────────────────────────────────────
+      - name: Run Claude Code Action
+        if: vars.SONAR_FIX_ACTIVE == 'true'
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are fixing SonarCloud issues for a single (rule × module) group.
+
+            Group ID: ${{ matrix.id }}
+            Rule: ${{ matrix.rule }}
+            Module: ${{ matrix.module }}
+            Reason: ${{ matrix.reason }}
+            Files to fix:
+            ${{ join(matrix.files, '\n') }}
+
+            Constraints:
+            - Only modify the listed files. Do not refactor unrelated code.
+            - Run `./gradlew :${{ matrix.module }}:ktlintFormat :${{ matrix.module }}:test`
+              before committing. If tests fail, retry once with adjusted approach.
+            - Commit message: `refactor(sonar): fix ${{ matrix.rule }} in ${{ matrix.module }}`
+            - Do NOT touch the allowlist or workflow files.
+
+      - name: Dry-run notice
+        if: vars.SONAR_FIX_ACTIVE != 'true'
+        env:
+          GROUP_ID: ${{ matrix.id }}
+        run: |
+          echo "::notice::Dry-run mode (SONAR_FIX_ACTIVE != 'true'). No PR will be created."
+          echo "Group: $GROUP_ID"
+          echo "Files: ${{ join(matrix.files, ' ') }}"
+
+      - name: Run local harness
+        if: vars.SONAR_FIX_ACTIVE == 'true'
+        run: ./gradlew ktlintCheck test --continue
+
+      - name: Push & open PR
+        if: vars.SONAR_FIX_ACTIVE == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -u origin "$BRANCH"
+          classification="${{ matrix.classification }}"
+          labels="sonar-auto-fix"
+          if [[ "$classification" == "auto_safe" ]]; then
+            labels="$labels,auto-merge"
+          else
+            labels="$labels,review-required"
+          fi
+          gh pr create \
+            --base dev \
+            --head "$BRANCH" \
+            --title "refactor(sonar): fix ${{ matrix.rule }} in ${{ matrix.module }}" \
+            --body "Auto-generated by sonar-fix.yml. Source issue: #${{ needs.parse.outputs.issue_number }}. Group: \`${{ matrix.id }}\` (${{ matrix.count }}건)." \
+            --label "$labels"
+
+  # ── Job 4: Report back to source issue ────────────────────────────
+  report:
+    name: Report to issue
+    needs: [parse, fix]
+    if: always() && needs.parse.outputs.issue_number != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ needs.parse.outputs.issue_number }}
+          FIX_RESULT: ${{ needs.fix.result }}
+        run: |
+          status_emoji='✅'
+          [[ "$FIX_RESULT" != "success" ]] && status_emoji='⚠️'
+          gh issue comment "$ISSUE_NUMBER" --body \
+            "$status_emoji sonar-fix run finished — result: \`$FIX_RESULT\`. See workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/sonar-fix.yml
+++ b/.github/workflows/sonar-fix.yml
@@ -9,8 +9,8 @@ name: Sonar Auto-Fix Dispatch
 #   3. 코멘트 작성자가 repo 의 write 권한 보유
 #
 # 안전장치:
-#   - 그룹별 worktree 분리, 동일 파일 충돌 시 직렬화 (parse 단계에서 감지)
-#   - 그룹별 최대 2회 재시도, 실패 시 이슈에 escalate 코멘트
+#   - max-parallel: 1 로 직렬 실행 — 동일 파일 충돌/race 방지
+#   - 실패 시 이슈에 escalate 코멘트
 #   - 🟡 그룹은 PR 만 생성, auto-merge 라벨 안 붙임
 #   - BUG 또는 VULNERABILITY 가 섞이면 자동 머지 차단
 
@@ -47,7 +47,8 @@ jobs:
     outputs:
       group_ids: ${{ steps.extract.outputs.group_ids }}
       issue_number: ${{ steps.extract.outputs.issue_number }}
-      authorized: ${{ steps.authz.outputs.authorized }}
+      # workflow_dispatch / issue_comment 두 경로 중 하나만 채워지므로 OR 결합.
+      authorized: ${{ steps.authz.outputs.authorized || steps.authz_dispatch.outputs.authorized }}
 
     steps:
       - name: Authorize commenter
@@ -69,9 +70,9 @@ jobs:
           fi
 
       - name: Authorize dispatch
+        id: authz_dispatch
         if: github.event_name == 'workflow_dispatch'
         run: echo "authorized=true" >> "$GITHUB_OUTPUT"
-        id: authz_dispatch
 
       - name: Checkout (for issue body parsing)
         if: github.event_name == 'issue_comment'
@@ -127,24 +128,13 @@ jobs:
           GROUP_IDS: ${{ needs.parse.outputs.group_ids }}
         run: |
           python3 .claude/scripts/sonar-fetch.py --output json > sonar.json
-          # 선택된 group_ids 만 남기고 file conflict 가 있으면 직렬화 마킹
+          # 선택된 group_ids 만 매트릭스로 변환. 직렬 실행은 strategy.max-parallel: 1
+          # 에서 일괄 적용하므로 그룹별 conflict_with 메타데이터는 채우지 않는다.
           python3 - "$GROUP_IDS" <<'PY' >> "$GITHUB_OUTPUT"
-          import json, sys, os
+          import json, sys
           ids = set(s.strip() for s in sys.argv[1].split(',') if s.strip())
           with open('sonar.json') as f: data = json.load(f)
           selected = [g for g in data['groups'] if g['id'] in ids]
-          # conflict detection: 같은 파일 등장 그룹 → conflict_with 채움
-          file_owners = {}
-          for g in selected:
-              for f in g['files']:
-                  file_owners.setdefault(f, []).append(g['id'])
-          for g in selected:
-              conflicts = set()
-              for f in g['files']:
-                  for other in file_owners[f]:
-                      if other != g['id']:
-                          conflicts.add(other)
-              g['conflicts_with'] = sorted(conflicts)
           matrix = {'include': selected}
           print(f"matrix={json.dumps(matrix)}")
           PY
@@ -157,7 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 3
+      # 같은 파일을 건드리는 그룹이 동시에 push 되면 race / rebase 가 발생하므로
+      # 안전하게 직렬화한다. 빈도가 주 1회 수준이라 처리량보다 안전성을 우선.
+      max-parallel: 1
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
 
     steps:
@@ -182,6 +174,19 @@ jobs:
           echo "BRANCH=$branch" >> "$GITHUB_ENV"
           git checkout -b "$branch"
 
+      # GitHub Actions expression 의 `'\n'` 은 리터럴 백슬래시-n 으로 해석되므로
+      # 파일 목록을 별도 step 에서 JSON 배열을 풀어 multiline 문자열로 만든다.
+      - name: Format file list
+        id: files
+        env:
+          FILES_JSON: ${{ toJson(matrix.files) }}
+        run: |
+          {
+            echo 'list<<__EOF__'
+            python3 -c "import json,os; print('\n'.join(json.loads(os.environ['FILES_JSON'])))"
+            echo '__EOF__'
+          } >> "$GITHUB_OUTPUT"
+
       # ─────────────────────────────────────────────────────────────
       # 활성화 모드: ANTHROPIC_API_KEY 가 secrets 에 있으면 Claude Code Action 으로 수정.
       # 비활성화 모드 (기본): stub 만 실행, PR 생성 안 함. 안전한 dry-run.
@@ -203,7 +208,7 @@ jobs:
             Module: ${{ matrix.module }}
             Reason: ${{ matrix.reason }}
             Files to fix:
-            ${{ join(matrix.files, '\n') }}
+            ${{ steps.files.outputs.list }}
 
             Constraints:
             - Only modify the listed files. Do not refactor unrelated code.

--- a/.github/workflows/sonar-issue.yml
+++ b/.github/workflows/sonar-issue.yml
@@ -1,11 +1,11 @@
 name: Sonar Auto-Fix Queue (Issue)
 
-# 매주 월요일 09:00 KST (= 일요일 24:00 UTC) 또는 수동 트리거 시 SonarCloud 결과를
+# 매일 00:00 KST (= 전날 15:00 UTC) 또는 수동 트리거 시 SonarCloud 결과를
 # 그룹화하여 GitHub Issue 체크리스트로 갱신한다.
 
 on:
   schedule:
-    - cron: '0 0 * * 1'   # Mon 00:00 UTC = Mon 09:00 KST
+    - cron: '0 15 * * *'   # 15:00 UTC = 00:00 KST (다음날)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sonar-issue.yml
+++ b/.github/workflows/sonar-issue.yml
@@ -1,0 +1,82 @@
+name: Sonar Auto-Fix Queue (Issue)
+
+# 매주 월요일 09:00 KST (= 일요일 24:00 UTC) 또는 수동 트리거 시 SonarCloud 결과를
+# 그룹화하여 GitHub Issue 체크리스트로 갱신한다.
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'   # Mon 00:00 UTC = Mon 09:00 KST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sonar-auto-fix-queue
+  cancel-in-progress: false
+
+env:
+  ISSUE_LABEL: sonar-auto-fix-queue
+  ISSUE_TITLE: '[Sonar] Auto-Fix Queue'
+
+jobs:
+  upsert-issue:
+    name: Upsert Sonar Issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Generate issue body
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          python3 .claude/scripts/sonar-fetch.py --output markdown > issue-body.md
+          echo "----- preview -----"
+          head -20 issue-body.md
+          echo "----- (truncated) -----"
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh label list --limit 200 | grep -q "^${ISSUE_LABEL}\b"; then
+            gh label create "$ISSUE_LABEL" \
+              --description "Sonar auto-fix queue (managed by sonar-issue.yml)" \
+              --color BFD4F2
+          fi
+
+      - name: Find existing open issue
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh issue list \
+            --label "$ISSUE_LABEL" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Update or create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING: ${{ steps.find.outputs.number }}
+        run: |
+          if [ -n "$EXISTING" ]; then
+            echo "Updating issue #$EXISTING"
+            gh issue edit "$EXISTING" --body-file issue-body.md
+          else
+            echo "Creating new issue"
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body-file issue-body.md \
+              --label "$ISSUE_LABEL"
+          fi


### PR DESCRIPTION
## Summary

기존 로컬 하네스(pre-commit/pre-push)와 `ci.yml` 위에 두 번째 컴파운딩 루프를 도입한다. SonarCloud 결과를 GitHub Issue 체크리스트로 큐잉 → 담당자 승인 → 그룹별로 Claude 가 PR 자동 생성하는 흐름. 로컬에서 닿지 않는 Sonar Quality Gate 의 결과를 액션 가능한 작업 단위로 환원하여, 한 머신·한 세션에 갇혀 있던 컴파운딩을 팀 단위 자산으로 확장한다.

### Allowlist 와 그룹핑

- `.claude/sonar-allowlist.yml` 에 룰을 **auto_safe / auto_with_review / manual_only** 로 분류하고, 공통 필터(`max_effort_minutes`, `min_age_days`, `exclude_paths`, unassigned 만 대상) 를 명시했다.
- `.claude/scripts/sonar-fetch.py` 가 SonarCloud API 를 호출해 allowlist 로 필터링한 뒤 `(rule × module)` 단위로 묶고, Issue 본문용 Markdown 또는 dispatch 용 JSON 을 출력한다.
- BUG 타입 이슈는 `auto_safe` 룰에 매칭되더라도 강제로 `auto_with_review` 로 격상 — 동작 변경 가능성이 있는 수정에는 자동 머지가 절대 발동하지 않도록 한다.

### Issue / Dispatch 워크플로우

- `.github/workflows/sonar-issue.yml` 은 매일 자정 (`workflow_dispatch`) 에 실행되어 `sonar-auto-fix-queue` 라벨이 붙은 Issue 1개를 upsert 한다.
- `.github/workflows/sonar-fix.yml` 은 `/sonar-fix run` 코멘트로 발동한다. (a) 코멘트 작성자의 write 권한 검증, (b) 체크된 그룹 ID 파싱, (c) 매트릭스 빌드 (같은 파일 충돌은 자동 직렬화), (d) 활성 모드일 때 `anthropics/claude-code-action@beta` 에 그룹별로 좁은 프롬프트를 전달한다.

### 활성화 게이트

기본은 **dry-run** — `ANTHROPIC_API_KEY` secret 과 `SONAR_FIX_ACTIVE=true` repo variable 둘 다 설정돼야 PR 생성이 작동한다. 그 전까지는 매트릭스만 빌드하고 dry-run notice 만 남긴다. 이 설계로 PR 머지 자체는 어떠한 동작 부수효과도 만들지 않는다.

### 로컬 검증 결과

현재 SonarCloud 데이터 (OPEN CODE_SMELL/BUG, MAJOR/MINOR 30건) 기준, 스크립트가 14개 auto-safe 그룹 + 13개 review 그룹 + 3건 manual 로 분류했다. 모든 그룹 ID 가 `sonar-fix.yml` 의 코멘트 파서 정규식과 매칭됨을 확인.

## Test plan

- [x] `./gradlew harness` 통과 (pre-push 에서 자동 검증)
- [x] `python3 .claude/scripts/sonar-fetch.py --input /tmp/sonar.json --output markdown` 으로 14 그룹 / 3 manual 분류 확인
- [x] 생성된 group ID 가 `sonar-fix.yml` 의 정규식 `[a-z_]+-[a-zA-Z0-9_]+-ssolv-[a-z-]+` 와 매칭됨을 확인
- [x] YAML lint 통과 (sonar-issue.yml, sonar-fix.yml, sonar-allowlist.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)