### PR TITLE
feat(monitoring): add Claude Code OTel telemetry pipeline

### DIFF
--- a/.claude/docs/monitoring/claude-code-dashboard.json
+++ b/.claude/docs/monitoring/claude-code-dashboard.json
@@ -1,0 +1,297 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__requires": [
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "datasource", "id": "loki", "name": "Loki", "version": "1.0.0" },
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "barchart", "name": "Bar chart", "version": "" },
+    { "type": "panel", "id": "logs", "name": "Logs", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Claude Code usage monitoring — token usage, cost, tool decisions, skill invocations, hook blocks",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Total Tokens (today)",
+      "type": "stat",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum(increase(claude_code_token_usage_total{developer=~\"$developer\"}[$__range]))",
+        "legendFormat": "tokens"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] },
+          "unit": "currencyUSD",
+          "decimals": 4
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Cost (today)",
+      "type": "stat",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum(increase(claude_code_cost_usage_total{developer=~\"$developer\"}[$__range]))",
+        "legendFormat": "USD"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Sessions (today)",
+      "type": "stat",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum(increase(claude_code_session_count_total{developer=~\"$developer\"}[$__range]))",
+        "legendFormat": "sessions"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Commits (today)",
+      "type": "stat",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum(increase(claude_code_commit_count_total{developer=~\"$developer\"}[$__range]))",
+        "legendFormat": "commits"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 50 }] },
+          "unit": "percent"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Edit Reject Rate",
+      "type": "stat",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "100 * sum(increase(claude_code_code_edit_tool_decision_total{decision=\"reject\",developer=~\"$developer\"}[$__range])) / clamp_min(sum(increase(claude_code_code_edit_tool_decision_total{developer=~\"$developer\"}[$__range])), 1)",
+        "legendFormat": "reject %"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "title": "Token & Cost Trends",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "cache_read" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "cache_creation" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "input" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "output" }, "properties": [{ "id": "color", "value": { "fixedColor": "purple", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 10,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Token Usage by Type",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (token_type) (rate(claude_code_token_usage_total{developer=~\"$developer\"}[$__rate_interval]))",
+          "legendFormat": "{{token_type}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "decimals": 6, "custom": { "lineWidth": 2, "fillOpacity": 20 } },
+        "overrides": [{ "matcher": { "id": "byName", "options": "cost" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 11,
+      "title": "Cost Over Time",
+      "type": "timeseries",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum(rate(claude_code_cost_usage_total{developer=~\"$developer\"}[$__rate_interval]))",
+        "legendFormat": "cost/s"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "title": "Tool & Edit Decisions",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "accept" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "reject" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 20,
+      "title": "Edit Accept vs Reject",
+      "type": "timeseries",
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "sum by (decision) (rate(claude_code_code_edit_tool_decision_total{developer=~\"$developer\"}[$__rate_interval]))",
+        "legendFormat": "{{decision}}"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 21,
+      "title": "Tool Usage Distribution",
+      "type": "barchart",
+      "options": { "orientation": "horizontal", "barWidth": 0.7 },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "expr": "topk(10, sum by (tool) (increase(claude_code_tool_decision_total{developer=~\"$developer\"}[$__range])))",
+        "legendFormat": "{{tool}}"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "title": "Skill Invocations & Hook Blocks",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 30,
+      "title": "Skill Invocations",
+      "type": "logs",
+      "options": { "dedupStrategy": "none", "showLabels": true, "showTime": true, "sortOrder": "Descending" },
+      "targets": [{
+        "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+        "expr": "{service_name=\"claude-code\", developer=~\"$developer\"} |= \"skill.invoked\" | json | line_format \"{{.skill_name}}\"",
+        "legendFormat": ""
+      }]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 31,
+      "title": "Hook Blocks",
+      "type": "logs",
+      "options": { "dedupStrategy": "none", "showLabels": true, "showTime": true, "sortOrder": "Descending" },
+      "targets": [{
+        "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+        "expr": "{service_name=\"claude-code\", developer=~\"$developer\"} |= \"hook.blocked\" | json | line_format \"[{{.hook_name}}] {{.reason}}\"",
+        "legendFormat": ""
+      }]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["claude-code", "monitoring", "ssolv"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(claude_code_token_usage_total, developer)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "developer",
+        "options": [],
+        "query": "label_values(claude_code_token_usage_total, developer)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query",
+        "label": "Developer"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Claude Code — Developer Monitoring",
+  "uid": "claude-code-monitoring",
+  "version": 1
+}

--- a/.claude/docs/monitoring/claude-code-setup.md
+++ b/.claude/docs/monitoring/claude-code-setup.md
@@ -28,6 +28,8 @@ export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://3.34.32.206:4318
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# cumulative: Prometheus 호환 백엔드가 delta temporality를 무음 드롭하는 것 방지
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative
 export OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code,developer=<본인-github-id>
 
 # 커스텀 훅 이벤트 엔드포인트 (네이티브 OTel과 동일 엔드포인트)
@@ -46,17 +48,6 @@ source ~/.zshrc
 ```
 ~/.claude/telemetry/events.jsonl
 ```
-
-## EC2 배포 시 필요한 env 키
-
-`deploy/.env`에 추가 필요한 환경 변수:
-
-```env
-GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-ap-southeast-0.grafana.net/otlp
-GRAFANA_CLOUD_INSTANCE_ID=<grafana-cloud-instance-id>
-```
-
-> `GRAFANA_CLOUD_API_KEY`는 기존 키 재사용.
 
 ## 구조
 

--- a/.claude/docs/monitoring/claude-code-setup.md
+++ b/.claude/docs/monitoring/claude-code-setup.md
@@ -1,0 +1,70 @@
+# Claude Code 모니터링 개발자 설정
+
+## 개요
+
+Claude Code 사용 지표(토큰/비용/tool 사용률)는 OTLP → Instance A Alloy → Grafana Cloud로 수집된다.
+스킬 호출 및 훅 차단 이벤트는 커스텀 훅이 별도 OTLP 로그로 전송한다.
+
+## 수집 지표
+
+| 지표 | 출처 | Grafana 위치 |
+|---|---|---|
+| 토큰 사용량 (input/output/cache) | `claude_code.token.usage` | Prometheus → Grafana |
+| API 비용 (USD) | `claude_code.cost.usage` | Prometheus → Grafana |
+| Edit 수락/거절 비율 | `claude_code.code_edit_tool.decision` | Prometheus → Grafana |
+| Tool 사용 분포 | `claude_code.tool_decision` | Prometheus → Grafana |
+| 커밋/PR 수 | `claude_code.commit.count` | Prometheus → Grafana |
+| 스킬 호출 이벤트 | `skill.invoked` (커스텀) | Loki → Grafana |
+| 훅 차단 이벤트 | `hook.blocked` (커스텀) | Loki → Grafana |
+
+## 로컬 환경 설정
+
+`~/.zshrc` (또는 `~/.zshenv`)에 추가:
+
+```bash
+# Claude Code OTel 텔레메트리
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://3.34.32.206:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_RESOURCE_ATTRIBUTES=service.name=claude-code,developer=<본인-github-id>
+
+# 커스텀 훅 이벤트 엔드포인트 (네이티브 OTel과 동일 엔드포인트)
+export CLAUDE_OTLP_ENDPOINT=http://3.34.32.206:4318
+```
+
+설정 후 적용:
+```bash
+source ~/.zshrc
+```
+
+## 로컬 이벤트 로그
+
+훅 이벤트는 OTLP 전송 실패 시에도 로컬에 보존된다:
+
+```
+~/.claude/telemetry/events.jsonl
+```
+
+## EC2 배포 시 필요한 env 키
+
+`deploy/.env`에 추가 필요한 환경 변수:
+
+```env
+GRAFANA_CLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-ap-southeast-0.grafana.net/otlp
+GRAFANA_CLOUD_INSTANCE_ID=<grafana-cloud-instance-id>
+```
+
+> `GRAFANA_CLOUD_API_KEY`는 기존 키 재사용.
+
+## 구조
+
+```
+로컬 Mac
+  Claude Code ──OTLP metrics──▶ Instance A :4318 ──▶ Grafana Cloud Prometheus
+  Hook events ──OTLP logs────▶ Instance A :4318 ──▶ Grafana Cloud Loki
+
+Instance A (3.34.32.206)
+  Alloy: OTLP receiver(4317/4318) + prometheus remote_write + loki write
+```

--- a/.claude/hooks/commit-msg-check.sh
+++ b/.claude/hooks/commit-msg-check.sh
@@ -100,6 +100,8 @@ else
     echo "   → 커밋 메시지는 영문으로 작성해야 합니다. (CLAUDE.md 규칙)"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
+    bash "$(dirname "$0")/telemetry-emit.sh" "hook.blocked" \
+        "hook_name=commit-msg-check" "reason=non-ascii" &
     exit 2
 fi
 
@@ -123,5 +125,7 @@ else
     echo "     refactor: remove unused benchmark dependencies"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
+    bash "$(dirname "$0")/telemetry-emit.sh" "hook.blocked" \
+        "hook_name=commit-msg-check" "reason=conventional-commits-violation" &
     exit 2
 fi

--- a/.claude/hooks/post-edit-dispatch.sh
+++ b/.claude/hooks/post-edit-dispatch.sh
@@ -24,12 +24,14 @@ HOOKS_DIR="$(dirname "$0")"
 # 차단 신호(exit 2)는 반드시 상위로 전파되어야 함 — 안 그러면 모든 blocking 훅이 무음 실패함.
 # 정책: 하나라도 exit 2 면 최종 exit 2. 그 외 비정상은 로그만 남기고 통과.
 FINAL_EXIT=0
+BLOCKED_HOOKS=()
 run_hook() {
     local hook="$1"
     echo "$TOOL_INPUT" | bash "$HOOKS_DIR/$hook"
     local rc=$?
     if [ "$rc" -eq 2 ]; then
         FINAL_EXIT=2
+        BLOCKED_HOOKS+=("$hook")
     elif [ "$rc" -ne 0 ]; then
         echo "⚠️  $hook exited with code $rc (non-blocking)" >&2
     fi
@@ -49,5 +51,13 @@ case "$FILE_PATH" in
         run_hook module-import-check.sh
         ;;
 esac
+
+if [ "$FINAL_EXIT" -eq 2 ]; then
+    for hook in "${BLOCKED_HOOKS[@]}"; do
+        bash "$HOOKS_DIR/telemetry-emit.sh" "hook.blocked" \
+            "hook_name=${hook%.sh}" \
+            "file_path=$FILE_PATH" &
+    done
+fi
 
 exit "$FINAL_EXIT"

--- a/.claude/hooks/skill-telemetry.sh
+++ b/.claude/hooks/skill-telemetry.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse(Skill) — 스킬 호출 이벤트 추적
+#
+# 어떤 skill이 얼마나 호출되는지 OTLP 로그로 기록한다.
+# settings.json: PreToolUse matcher "Skill"
+
+TOOL_INPUT=$(cat)
+
+SKILL_NAME=$(echo "$TOOL_INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    args = d.get('tool_input', {})
+    print(args.get('skill', args.get('name', 'unknown')))
+except:
+    print('unknown')
+" 2>/dev/null)
+
+HOOKS_DIR="$(dirname "$0")"
+bash "$HOOKS_DIR/telemetry-emit.sh" "skill.invoked" "skill_name=$SKILL_NAME" &
+
+exit 0

--- a/.claude/hooks/telemetry-emit.sh
+++ b/.claude/hooks/telemetry-emit.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Claude Code 텔레메트리 이벤트 전송 헬퍼
 #
-# 용도: 스킬 호출, 훅 차단 등 커스텀 이벤트를 OTLP HTTP로 Instance A Alloy에 전송.
+# 용도: 스킬 호출, 훅 차단 등 커스텀 이벤트를 OTLP HTTP로 Alloy에 전송.
 # 네이티브 claude_code.* 메트릭(토큰/비용/tool decision)은 CLAUDE_CODE_ENABLE_TELEMETRY로 별도 처리.
 #
 # 사용법:
-#   telemetry-emit.sh <event_name> [key=value ...]
+#   CLAUDE_OTLP_ENDPOINT=http://host:4318 telemetry-emit.sh <event_name> [key=value ...]
 #
 # 예시:
 #   telemetry-emit.sh hook.blocked hook_name=commit-msg-check reason=non-ascii
@@ -14,56 +14,73 @@
 EVENT_NAME="${1:-unknown}"
 shift
 
-OTLP_ENDPOINT="${CLAUDE_OTLP_ENDPOINT:-http://3.34.32.206:4318}"
+# CLAUDE_OTLP_ENDPOINT가 설정되지 않으면 OTLP 전송 생략 (로컬 JSONL만 기록)
+OTLP_ENDPOINT="${CLAUDE_OTLP_ENDPOINT:-}"
 LOG_FILE="${HOME}/.claude/telemetry/events.jsonl"
 
-# 로컬 JSONL에 항상 기록 (OTLP 실패해도 유실 없음)
 mkdir -p "$(dirname "$LOG_FILE")"
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-ATTRS="{}"
-for pair in "$@"; do
-    key="${pair%%=*}"
-    val="${pair#*=}"
-    ATTRS=$(printf '%s' "$ATTRS" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-d['$key'] = '$val'
-print(json.dumps(d))
-" 2>/dev/null || echo "$ATTRS")
-done
 
-printf '{"ts":"%s","event":"%s","attrs":%s}\n' "$TIMESTAMP" "$EVENT_NAME" "$ATTRS" >> "$LOG_FILE"
+# key=value 쌍을 Python으로 안전하게 처리 (셸 인젝션 방지)
+# 모든 값은 환경변수와 argv를 통해 Python으로 전달
+ATTRS_JSON=$(python3 - "$@" <<'PYEOF'
+import sys, json, os
+
+pairs = sys.argv[1:]
+attrs = {}
+for p in pairs:
+    if '=' in p:
+        k, _, v = p.partition('=')
+        attrs[k] = v
+print(json.dumps(attrs))
+PYEOF
+)
+ATTRS_JSON="${ATTRS_JSON:-{}}"
+
+# 로컬 JSONL에 항상 기록 (OTLP 실패해도 유실 없음)
+printf '{"ts":"%s","event":"%s","attrs":%s}\n' \
+    "$TIMESTAMP" "$EVENT_NAME" "$ATTRS_JSON" >> "$LOG_FILE"
+
+# OTLP 엔드포인트 미설정 시 종료
+[ -z "$OTLP_ENDPOINT" ] && exit 0
 
 # OTLP HTTP 전송 (백그라운드 — 느려도 훅 차단 안 함)
-NOW_NS=$(date +%s)000000000
-BODY=$(python3 -c "
-import json, sys
+NOW_NS="$(date +%s)000000000"
+BODY=$(EVENT_NAME="$EVENT_NAME" \
+       ATTRS_JSON="$ATTRS_JSON" \
+       DEVELOPER="${USER:-unknown}" \
+       NOW_NS="$NOW_NS" \
+       python3 - <<'PYEOF'
+import json, os
 
-attrs = json.loads('$ATTRS') if '$ATTRS' != '{}' else {}
-kv_list = [{'key': k, 'value': {'stringValue': v}} for k, v in attrs.items()]
-kv_list.append({'key': 'service.name', 'value': {'stringValue': 'claude-code'}})
-kv_list.append({'key': 'developer', 'value': {'stringValue': '${USER:-unknown}'}})
+event_name = os.environ["EVENT_NAME"]
+attrs      = json.loads(os.environ["ATTRS_JSON"])
+developer  = os.environ["DEVELOPER"]
+now_ns     = os.environ["NOW_NS"]
+
+kv_list = [{"key": k, "value": {"stringValue": v}} for k, v in attrs.items()]
 
 payload = {
-    'resourceLogs': [{
-        'resource': {
-            'attributes': [
-                {'key': 'service.name', 'value': {'stringValue': 'claude-code'}},
-                {'key': 'developer', 'value': {'stringValue': '${USER:-unknown}'}},
+    "resourceLogs": [{
+        "resource": {
+            "attributes": [
+                {"key": "service.name", "value": {"stringValue": "claude-code"}},
+                {"key": "developer",    "value": {"stringValue": developer}},
             ]
         },
-        'scopeLogs': [{
-            'logRecords': [{
-                'timeUnixNano': '${NOW_NS}',
-                'severityText': 'INFO',
-                'body': {'stringValue': '$EVENT_NAME'},
-                'attributes': kv_list,
+        "scopeLogs": [{
+            "logRecords": [{
+                "timeUnixNano": now_ns,
+                "severityText": "INFO",
+                "body": {"stringValue": event_name},
+                "attributes": kv_list,
             }]
         }]
     }]
 }
 print(json.dumps(payload))
-" 2>/dev/null)
+PYEOF
+)
 
 if [ -n "$BODY" ]; then
     curl -sf -X POST "${OTLP_ENDPOINT}/v1/logs" \

--- a/.claude/hooks/telemetry-emit.sh
+++ b/.claude/hooks/telemetry-emit.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Claude Code 텔레메트리 이벤트 전송 헬퍼
+#
+# 용도: 스킬 호출, 훅 차단 등 커스텀 이벤트를 OTLP HTTP로 Instance A Alloy에 전송.
+# 네이티브 claude_code.* 메트릭(토큰/비용/tool decision)은 CLAUDE_CODE_ENABLE_TELEMETRY로 별도 처리.
+#
+# 사용법:
+#   telemetry-emit.sh <event_name> [key=value ...]
+#
+# 예시:
+#   telemetry-emit.sh hook.blocked hook_name=commit-msg-check reason=non-ascii
+#   telemetry-emit.sh skill.invoked skill_name=git-conventions
+
+EVENT_NAME="${1:-unknown}"
+shift
+
+OTLP_ENDPOINT="${CLAUDE_OTLP_ENDPOINT:-http://3.34.32.206:4318}"
+LOG_FILE="${HOME}/.claude/telemetry/events.jsonl"
+
+# 로컬 JSONL에 항상 기록 (OTLP 실패해도 유실 없음)
+mkdir -p "$(dirname "$LOG_FILE")"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ATTRS="{}"
+for pair in "$@"; do
+    key="${pair%%=*}"
+    val="${pair#*=}"
+    ATTRS=$(printf '%s' "$ATTRS" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+d['$key'] = '$val'
+print(json.dumps(d))
+" 2>/dev/null || echo "$ATTRS")
+done
+
+printf '{"ts":"%s","event":"%s","attrs":%s}\n' "$TIMESTAMP" "$EVENT_NAME" "$ATTRS" >> "$LOG_FILE"
+
+# OTLP HTTP 전송 (백그라운드 — 느려도 훅 차단 안 함)
+NOW_NS=$(date +%s)000000000
+BODY=$(python3 -c "
+import json, sys
+
+attrs = json.loads('$ATTRS') if '$ATTRS' != '{}' else {}
+kv_list = [{'key': k, 'value': {'stringValue': v}} for k, v in attrs.items()]
+kv_list.append({'key': 'service.name', 'value': {'stringValue': 'claude-code'}})
+kv_list.append({'key': 'developer', 'value': {'stringValue': '${USER:-unknown}'}})
+
+payload = {
+    'resourceLogs': [{
+        'resource': {
+            'attributes': [
+                {'key': 'service.name', 'value': {'stringValue': 'claude-code'}},
+                {'key': 'developer', 'value': {'stringValue': '${USER:-unknown}'}},
+            ]
+        },
+        'scopeLogs': [{
+            'logRecords': [{
+                'timeUnixNano': '${NOW_NS}',
+                'severityText': 'INFO',
+                'body': {'stringValue': '$EVENT_NAME'},
+                'attributes': kv_list,
+            }]
+        }]
+    }]
+}
+print(json.dumps(payload))
+" 2>/dev/null)
+
+if [ -n "$BODY" ]; then
+    curl -sf -X POST "${OTLP_ENDPOINT}/v1/logs" \
+        -H "Content-Type: application/json" \
+        -d "$BODY" \
+        --max-time 2 \
+        > /dev/null 2>&1 &
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-telemetry.sh\"",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/deploy/docker-compose.instance-a.yml
+++ b/deploy/docker-compose.instance-a.yml
@@ -82,6 +82,7 @@ services:
     env_file:
       - .env
     ports:
+      # EC2 Security Group에서 팀 개발자 IP만 허용 필요 (4317/4318 unauthenticated)
       - "4317:4317" # OTLP gRPC — Claude Code 텔레메트리 수신
       - "4318:4318" # OTLP HTTP — Claude Code 텔레메트리 수신
     networks:

--- a/deploy/docker-compose.instance-a.yml
+++ b/deploy/docker-compose.instance-a.yml
@@ -81,6 +81,9 @@ services:
     command: run --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     env_file:
       - .env
+    ports:
+      - "4317:4317" # OTLP gRPC — Claude Code 텔레메트리 수신
+      - "4318:4318" # OTLP HTTP — Claude Code 텔레메트리 수신
     networks:
       - ssolv_prod_network
     mem_limit: 192m

--- a/ssolv-infrastructure/monitoring/alloy-config-instance-a.alloy
+++ b/ssolv-infrastructure/monitoring/alloy-config-instance-a.alloy
@@ -1,8 +1,7 @@
 // Instance A 전용 Alloy 설정
 // - 로그 수집: Docker 컨테이너 로그 → Grafana Cloud Loki
-// - OTLP 수신: Claude Code 텔레메트리(메트릭 + 로그) → Grafana Cloud
+// - OTLP 수신: Claude Code 텔레메트리(메트릭 + 로그) → 기존 Grafana Cloud 파이프라인 재사용
 // 메트릭 스크레이프는 Instance B의 Alloy가 원격으로 처리하므로 중복 수집 안 함
-// 트레이스도 Instance A의 app-server가 Instance B Alloy(OTLP :4318)로 직접 전송
 
 // ─── Claude Code 텔레메트리 수신 (OTLP) ──────────────────────────────────────
 
@@ -22,11 +21,11 @@ otelcol.receiver.otlp "claude_code" {
 otelcol.processor.batch "claude_code" {
   output {
     metrics = [otelcol.exporter.prometheus.claude_code.input]
-    logs    = [otelcol.exporter.otlphttp.claude_code_loki.input]
+    logs    = [otelcol.exporter.loki.claude_code.input]
   }
 }
 
-// Claude Code 메트릭 → Grafana Cloud Prometheus (remote_write)
+// Claude Code 메트릭 → 기존 Prometheus remote_write 파이프라인
 otelcol.exporter.prometheus "claude_code" {
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
@@ -41,17 +40,9 @@ prometheus.remote_write "grafana_cloud" {
   }
 }
 
-// Claude Code 로그(훅 이벤트, 스킬 호출) → Grafana Cloud Loki
-otelcol.exporter.otlphttp "claude_code_loki" {
-  client {
-    endpoint = sys.env("GRAFANA_CLOUD_OTLP_ENDPOINT")
-    auth     = otelcol.auth.basic.grafana_cloud.handler
-  }
-}
-
-otelcol.auth.basic "grafana_cloud" {
-  username = sys.env("GRAFANA_CLOUD_INSTANCE_ID")
-  password = sys.env("GRAFANA_CLOUD_API_KEY")
+// Claude Code 로그(훅 이벤트, 스킬 호출) → 기존 Loki write 파이프라인
+otelcol.exporter.loki "claude_code" {
+  forward_to = [loki.write.grafana_cloud.receiver]
 }
 
 // ─── 로그 수집 ────────────────────────────────────────────────────────────────

--- a/ssolv-infrastructure/monitoring/alloy-config-instance-a.alloy
+++ b/ssolv-infrastructure/monitoring/alloy-config-instance-a.alloy
@@ -1,6 +1,58 @@
-// Instance A 전용 Alloy 설정 — 로그 수집만 담당
+// Instance A 전용 Alloy 설정
+// - 로그 수집: Docker 컨테이너 로그 → Grafana Cloud Loki
+// - OTLP 수신: Claude Code 텔레메트리(메트릭 + 로그) → Grafana Cloud
 // 메트릭 스크레이프는 Instance B의 Alloy가 원격으로 처리하므로 중복 수집 안 함
 // 트레이스도 Instance A의 app-server가 Instance B Alloy(OTLP :4318)로 직접 전송
+
+// ─── Claude Code 텔레메트리 수신 (OTLP) ──────────────────────────────────────
+
+otelcol.receiver.otlp "claude_code" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.processor.batch.claude_code.input]
+    logs    = [otelcol.processor.batch.claude_code.input]
+  }
+}
+
+otelcol.processor.batch "claude_code" {
+  output {
+    metrics = [otelcol.exporter.prometheus.claude_code.input]
+    logs    = [otelcol.exporter.otlphttp.claude_code_loki.input]
+  }
+}
+
+// Claude Code 메트릭 → Grafana Cloud Prometheus (remote_write)
+otelcol.exporter.prometheus "claude_code" {
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_CLOUD_PROMETHEUS_URL")
+    basic_auth {
+      username = sys.env("GRAFANA_CLOUD_PROMETHEUS_USER")
+      password = sys.env("GRAFANA_CLOUD_API_KEY")
+    }
+  }
+}
+
+// Claude Code 로그(훅 이벤트, 스킬 호출) → Grafana Cloud Loki
+otelcol.exporter.otlphttp "claude_code_loki" {
+  client {
+    endpoint = sys.env("GRAFANA_CLOUD_OTLP_ENDPOINT")
+    auth     = otelcol.auth.basic.grafana_cloud.handler
+  }
+}
+
+otelcol.auth.basic "grafana_cloud" {
+  username = sys.env("GRAFANA_CLOUD_INSTANCE_ID")
+  password = sys.env("GRAFANA_CLOUD_API_KEY")
+}
 
 // ─── 로그 수집 ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

### 인프라 변경

- `alloy-config-instance-a.alloy`: OTLP receiver(4317/4318) 추가 — 수신한 메트릭은 Grafana Cloud Prometheus, 로그는 Loki로 포워딩 (기존 credentials 재사용, 신규 env var 없음)
- `docker-compose.instance-a.yml`: alloy 서비스에 OTLP 포트 노출

### 커스텀 훅 텔레메트리

- `telemetry-emit.sh`: OTLP HTTP 로그 이벤트 전송 헬퍼. `CLAUDE_OTLP_ENDPOINT` 미설정 시 전송 생략, 항상 `~/.claude/telemetry/events.jsonl`에 로컬 보존. 셸 인젝션 방지를 위해 Python에 env/argv로 값 전달
- `skill-telemetry.sh`: Skill PreToolUse 훅 — 어떤 스킬이 호출됐는지 기록
- `post-edit-dispatch.sh`: 차단된 훅 이름을 `hook.blocked` 이벤트로 emit
- `commit-msg-check.sh`: 차단 시 차단 사유(non-ascii / conventional-commits)를 emit
- `settings.json`: `PreToolUse(Skill)` 훅 등록

### 수집 지표 전체 목록

| 지표 | 출처 |
|---|---|
| `claude_code.token.usage` (input/output/cache) | Claude Code 네이티브 OTel |
| `claude_code.cost.usage` | Claude Code 네이티브 OTel |
| `claude_code.code_edit_tool.decision` | Claude Code 네이티브 OTel |
| `claude_code.tool_decision` | Claude Code 네이티브 OTel |
| `skill.invoked` (skill_name 포함) | `skill-telemetry.sh` |
| `hook.blocked` (hook_name, reason 포함) | `post-edit-dispatch.sh` / `commit-msg-check.sh` |

## Test plan

- [x] Instance A Alloy 재배포 후 `curl http://3.34.32.206:4318/v1/logs -d '{}'` 응답 확인 → `{"partialSuccess":{}}` 확인
- [x] `hook.blocked` 이벤트 JSONL 기록 확인 → `telemetry-emit.sh` 직접 실행으로 검증
- [x] `./gradlew harness` 통과 → pre-push 훅 통과 확인
- [ ] `CLAUDE_CODE_ENABLE_TELEMETRY=1` 설정 후 claude 실행 → Grafana Cloud Prometheus에서 `claude_code_token_usage` 확인 (로컬 env 설정 후 검증)
- [ ] skill 호출 시 `~/.claude/telemetry/events.jsonl`에 `skill.invoked` 이벤트 기록 확인 (로컬 env 설정 후 검증)

> **대시보드**: `.claude/docs/monitoring/claude-code-dashboard.json` → `https://ssolv.grafana.net` Dashboards → Import로 업로드

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)